### PR TITLE
update truth data GitHub action

### DIFF
--- a/.github/workflows/update_truth.yml
+++ b/.github/workflows/update_truth.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   update_truth_data:
+    if: github.repository_owner == 'cdcepi'
     runs-on: macOS-latest
     steps:    
       - name: Checkout repo


### PR DESCRIPTION
- With this change, truth data will only be updated in the official hub, not everyone's forked repo. 