### PR TITLE
Update update_truth.yml

### DIFF
--- a/.github/workflows/update_truth.yml
+++ b/.github/workflows/update_truth.yml
@@ -18,7 +18,9 @@ jobs:
         with: 
           fetch-depth: 0
       - name: Setup R 
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
+       with:
+         use-public-rspm: true
       - name: Install dependencies
         run: |
           install.packages(c("tidyverse", "dplyr", "readr", "covidcast", "lubridate", "httr", "jsonlite"))


### PR DESCRIPTION
fixes GitHub actions that use R that are failing at the step where they install R because of the use of a deprecated workflow step.