### PR TITLE
retro forecasts UMass-trends_ensemble

### DIFF
--- a/data-experimental/UMass-trends_ensemble/2022-10-17-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-10-17-UMass-trends_ensemble.csv
@@ -1,0 +1,173 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-10-17,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.0969749277807883
+2022-10-17,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.000108852592880959
+2022-10-17,"2 wk flu hosp rate change","04","Arizona","category","large_increase",1.11022302462516e-16
+2022-10-17,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.109078097792498
+2022-10-17,"2 wk flu hosp rate change","06","California","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",8.13127343235465e-12
+2022-10-17,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",5.46510600107908e-08
+2022-10-17,"2 wk flu hosp rate change","12","Florida","category","large_increase",9.3031138348465e-12
+2022-10-17,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.000435435221957436
+2022-10-17,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",6.40774352533846e-06
+2022-10-17,"2 wk flu hosp rate change","16","Idaho","category","large_increase",1.68753899743024e-14
+2022-10-17,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","18","Indiana","category","large_increase",5.50261705116739e-05
+2022-10-17,"2 wk flu hosp rate change","19","Iowa","category","large_increase",8.83428963982524e-07
+2022-10-17,"2 wk flu hosp rate change","20","Kansas","category","large_increase",2.81734731100158e-05
+2022-10-17,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.000102134044559943
+2022-10-17,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.0825571702751653
+2022-10-17,"2 wk flu hosp rate change","23","Maine","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","24","Maryland","category","large_increase",6.21724893790088e-15
+2022-10-17,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.288886539550576
+2022-10-17,"2 wk flu hosp rate change","29","Missouri","category","large_increase",8.38618063880858e-12
+2022-10-17,"2 wk flu hosp rate change","30","Montana","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.199596836916266
+2022-10-17,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.0136311205310675
+2022-10-17,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",7.74993513807942e-10
+2022-10-17,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.0497994506331445
+2022-10-17,"2 wk flu hosp rate change","36","New York","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","39","Ohio","category","large_increase",1.11022302462516e-15
+2022-10-17,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.000399647066498643
+2022-10-17,"2 wk flu hosp rate change","41","Oregon","category","large_increase",1.11022302462516e-16
+2022-10-17,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",1.25491766197472e-05
+2022-10-17,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.133326063857433
+2022-10-17,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.0313929224626118
+2022-10-17,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",3.70626661134743e-05
+2022-10-17,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.00305770008359341
+2022-10-17,"2 wk flu hosp rate change","48","Texas","category","large_increase",1.19480871751954e-07
+2022-10-17,"2 wk flu hosp rate change","US","US","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","49","Utah","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.00110431826332669
+2022-10-17,"2 wk flu hosp rate change","53","Washington","category","large_increase",1.70781033759226e-09
+2022-10-17,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.0145809638863041
+2022-10-17,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",0
+2022-10-17,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",4.39648317751562e-14
+2022-10-17,"2 wk flu hosp rate change","01","Alabama","category","increase",0.240582192954971
+2022-10-17,"2 wk flu hosp rate change","02","Alaska","category","increase",0.0313604520366637
+2022-10-17,"2 wk flu hosp rate change","04","Arizona","category","increase",9.40809838867462e-06
+2022-10-17,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.191485408244561
+2022-10-17,"2 wk flu hosp rate change","06","California","category","increase",7.21823931737475e-08
+2022-10-17,"2 wk flu hosp rate change","08","Colorado","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.000644587435059574
+2022-10-17,"2 wk flu hosp rate change","10","Delaware","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.00240854969957682
+2022-10-17,"2 wk flu hosp rate change","12","Florida","category","increase",0.000136229867137683
+2022-10-17,"2 wk flu hosp rate change","13","Georgia","category","increase",0.10287155479186
+2022-10-17,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.0321871074578058
+2022-10-17,"2 wk flu hosp rate change","16","Idaho","category","increase",0.000332845398737458
+2022-10-17,"2 wk flu hosp rate change","17","Illinois","category","increase",1.15116775323276e-05
+2022-10-17,"2 wk flu hosp rate change","18","Indiana","category","increase",0.0882429200736232
+2022-10-17,"2 wk flu hosp rate change","19","Iowa","category","increase",0.00569868884904889
+2022-10-17,"2 wk flu hosp rate change","20","Kansas","category","increase",0.0138104315165826
+2022-10-17,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.0997595623962824
+2022-10-17,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.236838926467333
+2022-10-17,"2 wk flu hosp rate change","23","Maine","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","24","Maryland","category","increase",0.000664845863590169
+2022-10-17,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","26","Michigan","category","increase",5.02106134447899e-11
+2022-10-17,"2 wk flu hosp rate change","27","Minnesota","category","increase",2.22044604925031e-15
+2022-10-17,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.171965745911708
+2022-10-17,"2 wk flu hosp rate change","29","Missouri","category","increase",0.00115013308614631
+2022-10-17,"2 wk flu hosp rate change","30","Montana","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.141388553970924
+2022-10-17,"2 wk flu hosp rate change","32","Nevada","category","increase",0.105730920900052
+2022-10-17,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.00356481979510004
+2022-10-17,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.161203427015771
+2022-10-17,"2 wk flu hosp rate change","36","New York","category","increase",2.92116631139816e-06
+2022-10-17,"2 wk flu hosp rate change","37","North Carolina","category","increase",1.91482052436243e-10
+2022-10-17,"2 wk flu hosp rate change","38","North Dakota","category","increase",1.61153490552124e-09
+2022-10-17,"2 wk flu hosp rate change","39","Ohio","category","increase",0.000122721849186269
+2022-10-17,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.065668426520928
+2022-10-17,"2 wk flu hosp rate change","41","Oregon","category","increase",8.06484881143987e-06
+2022-10-17,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.0321487397658032
+2022-10-17,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.135674169514127
+2022-10-17,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.200664680711962
+2022-10-17,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.0510620839473629
+2022-10-17,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.146772875969629
+2022-10-17,"2 wk flu hosp rate change","48","Texas","category","increase",0.0378957973739767
+2022-10-17,"2 wk flu hosp rate change","US","US","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","49","Utah","category","increase",2.10930792166053e-07
+2022-10-17,"2 wk flu hosp rate change","50","Vermont","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-10-17,"2 wk flu hosp rate change","51","Virginia","category","increase",0.106262027685927
+2022-10-17,"2 wk flu hosp rate change","53","Washington","category","increase",0.00101407831076061
+2022-10-17,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.236506281392954
+2022-10-17,"2 wk flu hosp rate change","55","Wisconsin","category","increase",4.26136903541874e-12
+2022-10-17,"2 wk flu hosp rate change","56","Wyoming","category","increase",7.68818644123481e-05
+2022-10-17,"2 wk flu hosp rate change","01","Alabama","category","stable",0.605419955257973
+2022-10-17,"2 wk flu hosp rate change","02","Alaska","category","stable",0.968530695370455
+2022-10-17,"2 wk flu hosp rate change","04","Arizona","category","stable",0.999990591901611
+2022-10-17,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.611461374146961
+2022-10-17,"2 wk flu hosp rate change","06","California","category","stable",0.999999927817607
+2022-10-17,"2 wk flu hosp rate change","08","Colorado","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.999355412556809
+2022-10-17,"2 wk flu hosp rate change","10","Delaware","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.997591395649363
+2022-10-17,"2 wk flu hosp rate change","12","Florida","category","stable",0.999863770123559
+2022-10-17,"2 wk flu hosp rate change","13","Georgia","category","stable",0.896126101320858
+2022-10-17,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.967806484798669
+2022-10-17,"2 wk flu hosp rate change","16","Idaho","category","stable",0.999667154601246
+2022-10-17,"2 wk flu hosp rate change","17","Illinois","category","stable",0.999988488322468
+2022-10-17,"2 wk flu hosp rate change","18","Indiana","category","stable",0.911702053755865
+2022-10-17,"2 wk flu hosp rate change","19","Iowa","category","stable",0.994300427721987
+2022-10-17,"2 wk flu hosp rate change","20","Kansas","category","stable",0.986161395010307
+2022-10-17,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.900138303559158
+2022-10-17,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.608191559674661
+2022-10-17,"2 wk flu hosp rate change","23","Maine","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","24","Maryland","category","stable",0.999335154136404
+2022-10-17,"2 wk flu hosp rate change","25","Massachusetts","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","26","Michigan","category","stable",0.999999999949789
+2022-10-17,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.999999999999998
+2022-10-17,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.349910231030844
+2022-10-17,"2 wk flu hosp rate change","29","Missouri","category","stable",0.998849866905468
+2022-10-17,"2 wk flu hosp rate change","30","Montana","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.65901460911281
+2022-10-17,"2 wk flu hosp rate change","32","Nevada","category","stable",0.880637958568881
+2022-10-17,"2 wk flu hosp rate change","33","New Hampshire","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.996435179429906
+2022-10-17,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.72140417512443
+2022-10-17,"2 wk flu hosp rate change","36","New York","category","stable",0.999997078833689
+2022-10-17,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.999999999808518
+2022-10-17,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.999999998388465
+2022-10-17,"2 wk flu hosp rate change","39","Ohio","category","stable",0.999877278150813
+2022-10-17,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.933931926412573
+2022-10-17,"2 wk flu hosp rate change","41","Oregon","category","stable",0.999991935151188
+2022-10-17,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.967838711057577
+2022-10-17,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.603212262343185
+2022-10-17,"2 wk flu hosp rate change","44","Rhode Island","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.767942396825426
+2022-10-17,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.948900853386524
+2022-10-17,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.850169423946777
+2022-10-17,"2 wk flu hosp rate change","48","Texas","category","stable",0.961971869565925
+2022-10-17,"2 wk flu hosp rate change","US","US","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","49","Utah","category","stable",0.999999789069208
+2022-10-17,"2 wk flu hosp rate change","50","Vermont","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-10-17,"2 wk flu hosp rate change","51","Virginia","category","stable",0.892633654050746
+2022-10-17,"2 wk flu hosp rate change","53","Washington","category","stable",0.998985919981429
+2022-10-17,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.748912754720742
+2022-10-17,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.999999999995739
+2022-10-17,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.999923118135544
+2022-10-17,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.0570229240062683
+2022-10-17,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.0879751198159798
+2022-10-17,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.00056690866532395
+2022-10-17,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.0724123435828406
+2022-10-17,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.172866260553893
+2022-10-17,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0675929472266543
+2022-10-17,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.117627092492856
+2022-10-17,"2 wk flu hosp rate change","48","Texas","category","decrease",0.000132213579226288
+2022-10-17,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.0163712229529789
+2022-10-17,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",0.0101604117923985

--- a/data-experimental/UMass-trends_ensemble/2022-10-24-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-10-24-UMass-trends_ensemble.csv
@@ -1,0 +1,179 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-10-24,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.1905035269113
+2022-10-24,"2 wk flu hosp rate change","02","Alaska","category","large_increase",3.69130544197738e-06
+2022-10-24,"2 wk flu hosp rate change","04","Arizona","category","large_increase",1.04259321176414e-08
+2022-10-24,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.143193677502363
+2022-10-24,"2 wk flu hosp rate change","06","California","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",9.0256760409968e-07
+2022-10-24,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",6.80130815311486e-06
+2022-10-24,"2 wk flu hosp rate change","12","Florida","category","large_increase",1.34292577058659e-12
+2022-10-24,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.00303992072184822
+2022-10-24,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",3.59490246643057e-05
+2022-10-24,"2 wk flu hosp rate change","16","Idaho","category","large_increase",1.29128705506076e-08
+2022-10-24,"2 wk flu hosp rate change","17","Illinois","category","large_increase",4.44089209850063e-16
+2022-10-24,"2 wk flu hosp rate change","18","Indiana","category","large_increase",2.64440860286985e-06
+2022-10-24,"2 wk flu hosp rate change","19","Iowa","category","large_increase",3.27150228841555e-05
+2022-10-24,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.000294766010602632
+2022-10-24,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",2.03449271141132e-06
+2022-10-24,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.113230299613194
+2022-10-24,"2 wk flu hosp rate change","23","Maine","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.00179630422322319
+2022-10-24,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",6.79851086538008e-09
+2022-10-24,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.183699588028037
+2022-10-24,"2 wk flu hosp rate change","29","Missouri","category","large_increase",5.89898744185469e-07
+2022-10-24,"2 wk flu hosp rate change","30","Montana","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.068401281164197
+2022-10-24,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.0168597263575164
+2022-10-24,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",7.89738650908145e-06
+2022-10-24,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.132191774378996
+2022-10-24,"2 wk flu hosp rate change","36","New York","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.00303898962476667
+2022-10-24,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",2.09159540909276e-07
+2022-10-24,"2 wk flu hosp rate change","39","Ohio","category","large_increase",2.8512192606911e-11
+2022-10-24,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",2.78164353189059e-05
+2022-10-24,"2 wk flu hosp rate change","41","Oregon","category","large_increase",3.3504354846059e-10
+2022-10-24,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",1.95841896344362e-06
+2022-10-24,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.188096574937003
+2022-10-24,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",4.50972592602739e-13
+2022-10-24,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.0594749325745961
+2022-10-24,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",0.000351674724009654
+2022-10-24,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.00993955862854756
+2022-10-24,"2 wk flu hosp rate change","48","Texas","category","large_increase",2.45072144799963e-08
+2022-10-24,"2 wk flu hosp rate change","US","US","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","49","Utah","category","large_increase",1.80183568065928e-08
+2022-10-24,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-10-24,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.00576228482009655
+2022-10-24,"2 wk flu hosp rate change","53","Washington","category","large_increase",3.67754549035482e-08
+2022-10-24,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.1277169495342
+2022-10-24,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",1.11022302462516e-16
+2022-10-24,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",7.1151973202177e-12
+2022-10-24,"2 wk flu hosp rate change","01","Alabama","category","increase",0.179310954248683
+2022-10-24,"2 wk flu hosp rate change","02","Alaska","category","increase",0.0256685760574072
+2022-10-24,"2 wk flu hosp rate change","04","Arizona","category","increase",0.00449906965520852
+2022-10-24,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.206492887647458
+2022-10-24,"2 wk flu hosp rate change","06","California","category","increase",4.46116477093028e-11
+2022-10-24,"2 wk flu hosp rate change","08","Colorado","category","increase",8.00292435654271e-08
+2022-10-24,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.0172887289689593
+2022-10-24,"2 wk flu hosp rate change","10","Delaware","category","increase",0
+2022-10-24,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.0249943783019045
+2022-10-24,"2 wk flu hosp rate change","12","Florida","category","increase",0.00109868766729004
+2022-10-24,"2 wk flu hosp rate change","13","Georgia","category","increase",0.144362217655957
+2022-10-24,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.0483231887563587
+2022-10-24,"2 wk flu hosp rate change","16","Idaho","category","increase",0.00143048970010706
+2022-10-24,"2 wk flu hosp rate change","17","Illinois","category","increase",5.81224946972769e-05
+2022-10-24,"2 wk flu hosp rate change","18","Indiana","category","increase",0.0372411831029895
+2022-10-24,"2 wk flu hosp rate change","19","Iowa","category","increase",0.0208653653100019
+2022-10-24,"2 wk flu hosp rate change","20","Kansas","category","increase",0.0315582549078162
+2022-10-24,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.0114477909490996
+2022-10-24,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.187118335859644
+2022-10-24,"2 wk flu hosp rate change","23","Maine","category","increase",0
+2022-10-24,"2 wk flu hosp rate change","24","Maryland","category","increase",0.118165398752467
+2022-10-24,"2 wk flu hosp rate change","25","Massachusetts","category","increase",5.86941872882107e-09
+2022-10-24,"2 wk flu hosp rate change","26","Michigan","category","increase",1.59513957598278e-10
+2022-10-24,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.00359203681153009
+2022-10-24,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.216105313942267
+2022-10-24,"2 wk flu hosp rate change","29","Missouri","category","increase",0.017848757722265
+2022-10-24,"2 wk flu hosp rate change","30","Montana","category","increase",0
+2022-10-24,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.141447965965104
+2022-10-24,"2 wk flu hosp rate change","32","Nevada","category","increase",0.11745918375664
+2022-10-24,"2 wk flu hosp rate change","33","New Hampshire","category","increase",1.73494552058173e-12
+2022-10-24,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.0134350344771265
+2022-10-24,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.17629201975664
+2022-10-24,"2 wk flu hosp rate change","36","New York","category","increase",4.21505719216952e-10
+2022-10-24,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.118246972340776
+2022-10-24,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.00356304247328976
+2022-10-24,"2 wk flu hosp rate change","39","Ohio","category","increase",0.00177973892865646
+2022-10-24,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.093327166765158
+2022-10-24,"2 wk flu hosp rate change","41","Oregon","category","increase",0.00095289767184048
+2022-10-24,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.0162949352490185
+2022-10-24,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.156521437360675
+2022-10-24,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.000167223899213531
+2022-10-24,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.176524266161071
+2022-10-24,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.0501472475376867
+2022-10-24,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.149415429397712
+2022-10-24,"2 wk flu hosp rate change","48","Texas","category","increase",0.00738014191595338
+2022-10-24,"2 wk flu hosp rate change","US","US","category","increase",0
+2022-10-24,"2 wk flu hosp rate change","49","Utah","category","increase",0.00983297696774199
+2022-10-24,"2 wk flu hosp rate change","50","Vermont","category","increase",6.0151883474191e-13
+2022-10-24,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-10-24,"2 wk flu hosp rate change","51","Virginia","category","increase",0.171989901637461
+2022-10-24,"2 wk flu hosp rate change","53","Washington","category","increase",0.00549952031184819
+2022-10-24,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.28840780272426
+2022-10-24,"2 wk flu hosp rate change","55","Wisconsin","category","increase",6.59436772364463e-05
+2022-10-24,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.000445884431059751
+2022-10-24,"2 wk flu hosp rate change","01","Alabama","category","stable",0.46870223058922
+2022-10-24,"2 wk flu hosp rate change","02","Alaska","category","stable",0.974327732637151
+2022-10-24,"2 wk flu hosp rate change","04","Arizona","category","stable",0.995500919918859
+2022-10-24,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.457167725482817
+2022-10-24,"2 wk flu hosp rate change","06","California","category","stable",0.999999999955388
+2022-10-24,"2 wk flu hosp rate change","08","Colorado","category","stable",0.999999919970756
+2022-10-24,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.982710368463437
+2022-10-24,"2 wk flu hosp rate change","10","Delaware","category","stable",1
+2022-10-24,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.974998820389942
+2022-10-24,"2 wk flu hosp rate change","12","Florida","category","stable",0.998901312331367
+2022-10-24,"2 wk flu hosp rate change","13","Georgia","category","stable",0.852070166245303
+2022-10-24,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.951640862218977
+2022-10-24,"2 wk flu hosp rate change","16","Idaho","category","stable",0.998569497387022
+2022-10-24,"2 wk flu hosp rate change","17","Illinois","category","stable",0.999941877505302
+2022-10-24,"2 wk flu hosp rate change","18","Indiana","category","stable",0.962756172488407
+2022-10-24,"2 wk flu hosp rate change","19","Iowa","category","stable",0.979101919667114
+2022-10-24,"2 wk flu hosp rate change","20","Kansas","category","stable",0.968146979081581
+2022-10-24,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.988550174558189
+2022-10-24,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.505357865695561
+2022-10-24,"2 wk flu hosp rate change","23","Maine","category","stable",1
+2022-10-24,"2 wk flu hosp rate change","24","Maryland","category","stable",0.880038297024309
+2022-10-24,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.999999994130581
+2022-10-24,"2 wk flu hosp rate change","26","Michigan","category","stable",0.999999999840486
+2022-10-24,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.996407956389959
+2022-10-24,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.429614323343372
+2022-10-24,"2 wk flu hosp rate change","29","Missouri","category","stable",0.982150652378991
+2022-10-24,"2 wk flu hosp rate change","30","Montana","category","stable",1
+2022-10-24,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.790150752870699
+2022-10-24,"2 wk flu hosp rate change","32","Nevada","category","stable",0.865681089885843
+2022-10-24,"2 wk flu hosp rate change","33","New Hampshire","category","stable",0.999999999998265
+2022-10-24,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.986557068136364
+2022-10-24,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.493761503092991
+2022-10-24,"2 wk flu hosp rate change","36","New York","category","stable",0.999999999578494
+2022-10-24,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.878714038034457
+2022-10-24,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.996436748367169
+2022-10-24,"2 wk flu hosp rate change","39","Ohio","category","stable",0.998220261042831
+2022-10-24,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.906645016799523
+2022-10-24,"2 wk flu hosp rate change","41","Oregon","category","stable",0.999047101993116
+2022-10-24,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.983703106332018
+2022-10-24,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.5752604449309
+2022-10-24,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.999832776100335
+2022-10-24,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.642810091751922
+2022-10-24,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.949501077738304
+2022-10-24,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.840622220126336
+2022-10-24,"2 wk flu hosp rate change","48","Texas","category","stable",0.983687937994143
+2022-10-24,"2 wk flu hosp rate change","US","US","category","stable",1
+2022-10-24,"2 wk flu hosp rate change","49","Utah","category","stable",0.990167005013901
+2022-10-24,"2 wk flu hosp rate change","50","Vermont","category","stable",0.999999999999398
+2022-10-24,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-10-24,"2 wk flu hosp rate change","51","Virginia","category","stable",0.821694647399283
+2022-10-24,"2 wk flu hosp rate change","53","Washington","category","stable",0.994500442912697
+2022-10-24,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.580304194261916
+2022-10-24,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.999934056322763
+2022-10-24,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.999554115561825
+2022-10-24,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.148063204032406
+2022-10-24,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.193145709367362
+2022-10-24,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.000527695376891644
+2022-10-24,"2 wk flu hosp rate change","18","Indiana","category","decrease",5.44954742802435e-16
+2022-10-24,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.193851626975257
+2022-10-24,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.145890378800579
+2022-10-24,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.197754702771374
+2022-10-24,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.0801215427714217
+2022-10-24,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.121190709512411
+2022-10-24,"2 wk flu hosp rate change","47","Tennessee","category","decrease",2.27918474046772e-05
+2022-10-24,"2 wk flu hosp rate change","48","Texas","category","decrease",0.00893189558268905
+2022-10-24,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.000553166143160125
+2022-10-24,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.00357105347962413
+2022-10-24,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.0134200842183908
+2022-10-24,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.000441871856344545
+2022-10-24,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.0246903958857444

--- a/data-experimental/UMass-trends_ensemble/2022-10-31-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-10-31-UMass-trends_ensemble.csv
@@ -1,0 +1,197 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-10-31,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.370674873417389
+2022-10-31,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.00243490899751764
+2022-10-31,"2 wk flu hosp rate change","04","Arizona","category","large_increase",0.00950472189561269
+2022-10-31,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.350046463190092
+2022-10-31,"2 wk flu hosp rate change","06","California","category","large_increase",0
+2022-10-31,"2 wk flu hosp rate change","08","Colorado","category","large_increase",3.51562177813847e-07
+2022-10-31,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",0.123986200723524
+2022-10-31,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0.00137791347993677
+2022-10-31,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",0.0175765643073917
+2022-10-31,"2 wk flu hosp rate change","12","Florida","category","large_increase",0.00338172571778661
+2022-10-31,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.0642052525953242
+2022-10-31,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",8.9830470277219e-05
+2022-10-31,"2 wk flu hosp rate change","16","Idaho","category","large_increase",1.15463194561016e-14
+2022-10-31,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0.000695188942374747
+2022-10-31,"2 wk flu hosp rate change","18","Indiana","category","large_increase",0.0217799539723786
+2022-10-31,"2 wk flu hosp rate change","19","Iowa","category","large_increase",7.27472862011025e-05
+2022-10-31,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.024830501389971
+2022-10-31,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.12799780607135
+2022-10-31,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.354928123872463
+2022-10-31,"2 wk flu hosp rate change","23","Maine","category","large_increase",6.33315174747295e-08
+2022-10-31,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.0843633153732967
+2022-10-31,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",2.03170813506404e-14
+2022-10-31,"2 wk flu hosp rate change","26","Michigan","category","large_increase",2.8314654340944e-05
+2022-10-31,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",2.57693083716148e-06
+2022-10-31,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.354376496552562
+2022-10-31,"2 wk flu hosp rate change","29","Missouri","category","large_increase",0.00021900362089422
+2022-10-31,"2 wk flu hosp rate change","30","Montana","category","large_increase",7.19251880276772e-10
+2022-10-31,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.0369458294958962
+2022-10-31,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.0176924267220711
+2022-10-31,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0
+2022-10-31,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",0.00598573555294124
+2022-10-31,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.274024446544916
+2022-10-31,"2 wk flu hosp rate change","36","New York","category","large_increase",1.31523680835244e-11
+2022-10-31,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.225253222643126
+2022-10-31,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",5.23183718570408e-11
+2022-10-31,"2 wk flu hosp rate change","39","Ohio","category","large_increase",0.0107227150355236
+2022-10-31,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.0291009997369079
+2022-10-31,"2 wk flu hosp rate change","41","Oregon","category","large_increase",6.31186103383641e-10
+2022-10-31,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",0.021029279820556
+2022-10-31,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.116480286070894
+2022-10-31,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",3.80029341329191e-13
+2022-10-31,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.343152074715885
+2022-10-31,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",7.48836836872435e-06
+2022-10-31,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.131526417911003
+2022-10-31,"2 wk flu hosp rate change","48","Texas","category","large_increase",0.00065351586189355
+2022-10-31,"2 wk flu hosp rate change","US","US","category","large_increase",1.96411994430878e-05
+2022-10-31,"2 wk flu hosp rate change","49","Utah","category","large_increase",0.000733751576989405
+2022-10-31,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0
+2022-10-31,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-10-31,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.090850397484969
+2022-10-31,"2 wk flu hosp rate change","53","Washington","category","large_increase",7.7715611723761e-16
+2022-10-31,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.22918380385709
+2022-10-31,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",1.94724187885242e-08
+2022-10-31,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",2.61054131855953e-06
+2022-10-31,"2 wk flu hosp rate change","01","Alabama","category","increase",0.175024959544241
+2022-10-31,"2 wk flu hosp rate change","02","Alaska","category","increase",0.0786730327862242
+2022-10-31,"2 wk flu hosp rate change","04","Arizona","category","increase",0.179792876396113
+2022-10-31,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.113905426528624
+2022-10-31,"2 wk flu hosp rate change","06","California","category","increase",1.06021739836315e-05
+2022-10-31,"2 wk flu hosp rate change","08","Colorado","category","increase",0.0248552518556765
+2022-10-31,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.142802108717082
+2022-10-31,"2 wk flu hosp rate change","10","Delaware","category","increase",0.0716340976286791
+2022-10-31,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.18097612121696
+2022-10-31,"2 wk flu hosp rate change","12","Florida","category","increase",0.119432317076039
+2022-10-31,"2 wk flu hosp rate change","13","Georgia","category","increase",0.249911712339416
+2022-10-31,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.0709704417274362
+2022-10-31,"2 wk flu hosp rate change","16","Idaho","category","increase",0.000189255352947004
+2022-10-31,"2 wk flu hosp rate change","17","Illinois","category","increase",0.0881497507327912
+2022-10-31,"2 wk flu hosp rate change","18","Indiana","category","increase",0.215252738862911
+2022-10-31,"2 wk flu hosp rate change","19","Iowa","category","increase",0.0652916804582874
+2022-10-31,"2 wk flu hosp rate change","20","Kansas","category","increase",0.16440154075464
+2022-10-31,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.226792505406673
+2022-10-31,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.13456278516077
+2022-10-31,"2 wk flu hosp rate change","23","Maine","category","increase",0.00176184707890548
+2022-10-31,"2 wk flu hosp rate change","24","Maryland","category","increase",0.237605226275363
+2022-10-31,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0.000691606601534889
+2022-10-31,"2 wk flu hosp rate change","26","Michigan","category","increase",0.0393218769740572
+2022-10-31,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.0540573076104787
+2022-10-31,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.113967141385903
+2022-10-31,"2 wk flu hosp rate change","29","Missouri","category","increase",0.0945307591805314
+2022-10-31,"2 wk flu hosp rate change","30","Montana","category","increase",0.00412649056581083
+2022-10-31,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.126952389438568
+2022-10-31,"2 wk flu hosp rate change","32","Nevada","category","increase",0.0989948173307114
+2022-10-31,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0
+2022-10-31,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.115185032358324
+2022-10-31,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.183508747303297
+2022-10-31,"2 wk flu hosp rate change","36","New York","category","increase",0.000629859040493508
+2022-10-31,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.180461342499289
+2022-10-31,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.00137669294411868
+2022-10-31,"2 wk flu hosp rate change","39","Ohio","category","increase",0.139148228767161
+2022-10-31,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.201119491172603
+2022-10-31,"2 wk flu hosp rate change","41","Oregon","category","increase",0.00179236389285442
+2022-10-31,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.189447351279384
+2022-10-31,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.234198846512298
+2022-10-31,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.000481107930456637
+2022-10-31,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.139397305449286
+2022-10-31,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.0249997725084748
+2022-10-31,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.247368238034805
+2022-10-31,"2 wk flu hosp rate change","48","Texas","category","increase",0.182471578823589
+2022-10-31,"2 wk flu hosp rate change","US","US","category","increase",0.037132703103802
+2022-10-31,"2 wk flu hosp rate change","49","Utah","category","increase",0.0825974667469445
+2022-10-31,"2 wk flu hosp rate change","50","Vermont","category","increase",0
+2022-10-31,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-10-31,"2 wk flu hosp rate change","51","Virginia","category","increase",0.233893043247662
+2022-10-31,"2 wk flu hosp rate change","53","Washington","category","increase",0.000719470289409108
+2022-10-31,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.181488630232349
+2022-10-31,"2 wk flu hosp rate change","55","Wisconsin","category","increase",0.0113496910907445
+2022-10-31,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.0104820913166979
+2022-10-31,"2 wk flu hosp rate change","01","Alabama","category","stable",0.357049232149487
+2022-10-31,"2 wk flu hosp rate change","02","Alaska","category","stable",0.918892058216258
+2022-10-31,"2 wk flu hosp rate change","04","Arizona","category","stable",0.810702401708274
+2022-10-31,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.331077365090592
+2022-10-31,"2 wk flu hosp rate change","06","California","category","stable",0.999989397826016
+2022-10-31,"2 wk flu hosp rate change","08","Colorado","category","stable",0.975144396582146
+2022-10-31,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.650896313763003
+2022-10-31,"2 wk flu hosp rate change","10","Delaware","category","stable",0.926987988891384
+2022-10-31,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.801447314475648
+2022-10-31,"2 wk flu hosp rate change","12","Florida","category","stable",0.875511596097475
+2022-10-31,"2 wk flu hosp rate change","13","Georgia","category","stable",0.62190832600933
+2022-10-31,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.928939727802287
+2022-10-31,"2 wk flu hosp rate change","16","Idaho","category","stable",0.999810744647041
+2022-10-31,"2 wk flu hosp rate change","17","Illinois","category","stable",0.911155060324834
+2022-10-31,"2 wk flu hosp rate change","18","Indiana","category","stable",0.749484884717704
+2022-10-31,"2 wk flu hosp rate change","19","Iowa","category","stable",0.934635572255512
+2022-10-31,"2 wk flu hosp rate change","20","Kansas","category","stable",0.810767957855389
+2022-10-31,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.572406623312934
+2022-10-31,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.385005347571145
+2022-10-31,"2 wk flu hosp rate change","23","Maine","category","stable",0.998238089589577
+2022-10-31,"2 wk flu hosp rate change","24","Maryland","category","stable",0.577227777490426
+2022-10-31,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.999308393398445
+2022-10-31,"2 wk flu hosp rate change","26","Michigan","category","stable",0.960649808371602
+2022-10-31,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.945940115458684
+2022-10-31,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.24221567707143
+2022-10-31,"2 wk flu hosp rate change","29","Missouri","category","stable",0.905250237198574
+2022-10-31,"2 wk flu hosp rate change","30","Montana","category","stable",0.995873508714937
+2022-10-31,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.836101781065536
+2022-10-31,"2 wk flu hosp rate change","32","Nevada","category","stable",0.883312755947218
+2022-10-31,"2 wk flu hosp rate change","33","New Hampshire","category","stable",1
+2022-10-31,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.878829232088735
+2022-10-31,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.427875198550028
+2022-10-31,"2 wk flu hosp rate change","36","New York","category","stable",0.999370140946354
+2022-10-31,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.555580889086505
+2022-10-31,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.998623307003563
+2022-10-31,"2 wk flu hosp rate change","39","Ohio","category","stable",0.8420390297701
+2022-10-31,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.736346726135703
+2022-10-31,"2 wk flu hosp rate change","41","Oregon","category","stable",0.998207635475959
+2022-10-31,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.771884431785167
+2022-10-31,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.57626756361368
+2022-10-31,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.999518892069163
+2022-10-31,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.42744721795957
+2022-10-31,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.974992739123156
+2022-10-31,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.52367038778431
+2022-10-31,"2 wk flu hosp rate change","48","Texas","category","stable",0.79991979500454
+2022-10-31,"2 wk flu hosp rate change","US","US","category","stable",0.962847655696674
+2022-10-31,"2 wk flu hosp rate change","49","Utah","category","stable",0.916668781676066
+2022-10-31,"2 wk flu hosp rate change","50","Vermont","category","stable",1
+2022-10-31,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-10-31,"2 wk flu hosp rate change","51","Virginia","category","stable",0.57554413093245
+2022-10-31,"2 wk flu hosp rate change","53","Washington","category","stable",0.99928052971059
+2022-10-31,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.364602903693676
+2022-10-31,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.988650289436837
+2022-10-31,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.989515298141984
+2022-10-31,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.0566612575863758
+2022-10-31,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.12897266978076
+2022-10-31,"2 wk flu hosp rate change","09","Connecticut","category","decrease",0.0823153767963913
+2022-10-31,"2 wk flu hosp rate change","12","Florida","category","decrease",0.00167436110869941
+2022-10-31,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.0639747090559301
+2022-10-31,"2 wk flu hosp rate change","18","Indiana","category","decrease",0.0134824224470064
+2022-10-31,"2 wk flu hosp rate change","21","Kentucky","category","decrease",0.0728030652090422
+2022-10-31,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.0715529320823645
+2022-10-31,"2 wk flu hosp rate change","24","Maryland","category","decrease",0.100803680860914
+2022-10-31,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.149089760094654
+2022-10-31,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0867038237846229
+2022-10-31,"2 wk flu hosp rate change","37","North Carolina","category","decrease",0.0346151074820811
+2022-10-31,"2 wk flu hosp rate change","39","Ohio","category","decrease",0.00809002642721614
+2022-10-31,"2 wk flu hosp rate change","40","Oklahoma","category","decrease",0.033432782954786
+2022-10-31,"2 wk flu hosp rate change","42","Pennsylvania","category","decrease",0.0176389371148932
+2022-10-31,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.0721033493152229
+2022-10-31,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.0611323148029352
+2022-10-31,"2 wk flu hosp rate change","47","Tennessee","category","decrease",0.0963343962299209
+2022-10-31,"2 wk flu hosp rate change","48","Texas","category","decrease",0.0169530650608139
+2022-10-31,"2 wk flu hosp rate change","US","US","category","decrease",8.04772034416712e-14
+2022-10-31,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.0970090833147082
+2022-10-31,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.164325918065461
+2022-10-31,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.0405896773025065
+2022-10-31,"2 wk flu hosp rate change","05","Arkansas","category","large_decrease",0.075998075409932
+2022-10-31,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.0539508113132582
+2022-10-31,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.14035092489545
+2022-10-31,"2 wk flu hosp rate change","35","New Mexico","category","large_decrease",0.0278877838171358
+2022-10-31,"2 wk flu hosp rate change","37","North Carolina","category","large_decrease",0.00408943828899896
+2022-10-31,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",0.00094995448790553
+2022-10-31,"2 wk flu hosp rate change","45","South Carolina","category","large_decrease",0.0288710870723227
+2022-10-31,"2 wk flu hosp rate change","47","Tennessee","category","large_decrease",0.00110056003996164
+2022-10-31,"2 wk flu hosp rate change","48","Texas","category","large_decrease",2.04524916291669e-06
+2022-10-31,"2 wk flu hosp rate change","51","Virginia","category","large_decrease",0.0027033450202116
+2022-10-31,"2 wk flu hosp rate change","54","West Virginia","category","large_decrease",0.0603987441514243

--- a/data-experimental/UMass-trends_ensemble/2022-11-07-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-11-07-UMass-trends_ensemble.csv
@@ -1,0 +1,211 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-11-07,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.528672927481947
+2022-11-07,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.0879717552552333
+2022-11-07,"2 wk flu hosp rate change","04","Arizona","category","large_increase",0.0564922862451032
+2022-11-07,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.336265770502839
+2022-11-07,"2 wk flu hosp rate change","06","California","category","large_increase",0.000536247668940115
+2022-11-07,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0.000319729283000614
+2022-11-07,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",0.160606213126969
+2022-11-07,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0.00775870274468715
+2022-11-07,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",0.259682294921458
+2022-11-07,"2 wk flu hosp rate change","12","Florida","category","large_increase",0.00495209258428264
+2022-11-07,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.0757639663249675
+2022-11-07,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",0.0067495700566681
+2022-11-07,"2 wk flu hosp rate change","16","Idaho","category","large_increase",0.071736143875676
+2022-11-07,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0.0116185098746414
+2022-11-07,"2 wk flu hosp rate change","18","Indiana","category","large_increase",0.134216764407666
+2022-11-07,"2 wk flu hosp rate change","19","Iowa","category","large_increase",2.1884086575108e-06
+2022-11-07,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.106651020606294
+2022-11-07,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.309742671432661
+2022-11-07,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.275402078279138
+2022-11-07,"2 wk flu hosp rate change","23","Maine","category","large_increase",1.05222619739553e-05
+2022-11-07,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.162684893687476
+2022-11-07,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0.00013098421949187
+2022-11-07,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0.000219392073369407
+2022-11-07,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",0.19082180325022
+2022-11-07,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.40938296091133
+2022-11-07,"2 wk flu hosp rate change","29","Missouri","category","large_increase",0.0196262054091972
+2022-11-07,"2 wk flu hosp rate change","30","Montana","category","large_increase",0.000771485096484725
+2022-11-07,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.142385199050001
+2022-11-07,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.0850562630568933
+2022-11-07,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",5.43709481894972e-05
+2022-11-07,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",0.0836179601232202
+2022-11-07,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.386738133365013
+2022-11-07,"2 wk flu hosp rate change","36","New York","category","large_increase",1.92341671436669e-05
+2022-11-07,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.156299889320663
+2022-11-07,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",0.00029997200463483
+2022-11-07,"2 wk flu hosp rate change","39","Ohio","category","large_increase",0.0904560254567676
+2022-11-07,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.000686232888788219
+2022-11-07,"2 wk flu hosp rate change","41","Oregon","category","large_increase",0.0499922603199542
+2022-11-07,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",0.0267975015700976
+2022-11-07,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.326283212183835
+2022-11-07,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",1.33620015052571e-09
+2022-11-07,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.411852301457878
+2022-11-07,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",5.72181130842342e-06
+2022-11-07,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.29818964340152
+2022-11-07,"2 wk flu hosp rate change","48","Texas","category","large_increase",0.0855928748610156
+2022-11-07,"2 wk flu hosp rate change","US","US","category","large_increase",0.00231578860461246
+2022-11-07,"2 wk flu hosp rate change","49","Utah","category","large_increase",0.000906627706959262
+2022-11-07,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0
+2022-11-07,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-11-07,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.239018380903934
+2022-11-07,"2 wk flu hosp rate change","53","Washington","category","large_increase",1.24967618808647e-07
+2022-11-07,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.325431787873244
+2022-11-07,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",9.23421239473754e-08
+2022-11-07,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",0.000727300017800303
+2022-11-07,"2 wk flu hosp rate change","01","Alabama","category","increase",0.174160972298219
+2022-11-07,"2 wk flu hosp rate change","02","Alaska","category","increase",0.195479798761489
+2022-11-07,"2 wk flu hosp rate change","04","Arizona","category","increase",0.211053302999667
+2022-11-07,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.0896340955319774
+2022-11-07,"2 wk flu hosp rate change","06","California","category","increase",0.0581460615149877
+2022-11-07,"2 wk flu hosp rate change","08","Colorado","category","increase",0.10000844153312
+2022-11-07,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.173380940547453
+2022-11-07,"2 wk flu hosp rate change","10","Delaware","category","increase",0.153448480918778
+2022-11-07,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.1603051397291
+2022-11-07,"2 wk flu hosp rate change","12","Florida","category","increase",0.123357724802463
+2022-11-07,"2 wk flu hosp rate change","13","Georgia","category","increase",0.229736637661504
+2022-11-07,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.129604103784763
+2022-11-07,"2 wk flu hosp rate change","16","Idaho","category","increase",0.188533165157792
+2022-11-07,"2 wk flu hosp rate change","17","Illinois","category","increase",0.243945311658001
+2022-11-07,"2 wk flu hosp rate change","18","Indiana","category","increase",0.249845415033387
+2022-11-07,"2 wk flu hosp rate change","19","Iowa","category","increase",0.0436208303557648
+2022-11-07,"2 wk flu hosp rate change","20","Kansas","category","increase",0.232793195954706
+2022-11-07,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.148414916863412
+2022-11-07,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.139182681068419
+2022-11-07,"2 wk flu hosp rate change","23","Maine","category","increase",0.00757025206225326
+2022-11-07,"2 wk flu hosp rate change","24","Maryland","category","increase",0.206885914857182
+2022-11-07,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0.0716420171777237
+2022-11-07,"2 wk flu hosp rate change","26","Michigan","category","increase",0.0555783358246131
+2022-11-07,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.201691625654875
+2022-11-07,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.121168418759657
+2022-11-07,"2 wk flu hosp rate change","29","Missouri","category","increase",0.230663015645575
+2022-11-07,"2 wk flu hosp rate change","30","Montana","category","increase",0.0664642910482429
+2022-11-07,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.223118560779106
+2022-11-07,"2 wk flu hosp rate change","32","Nevada","category","increase",0.181835755069518
+2022-11-07,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0.0255740958835586
+2022-11-07,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.231468172474087
+2022-11-07,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.146967940433603
+2022-11-07,"2 wk flu hosp rate change","36","New York","category","increase",0.10637581142724
+2022-11-07,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.225199970323116
+2022-11-07,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.0507053883524918
+2022-11-07,"2 wk flu hosp rate change","39","Ohio","category","increase",0.191685855376325
+2022-11-07,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.194478512321624
+2022-11-07,"2 wk flu hosp rate change","41","Oregon","category","increase",0.230917836529561
+2022-11-07,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.198601574041488
+2022-11-07,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.133729700673444
+2022-11-07,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.01036353608681
+2022-11-07,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.196293433867194
+2022-11-07,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.0250004386338311
+2022-11-07,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.142200198264317
+2022-11-07,"2 wk flu hosp rate change","48","Texas","category","increase",0.275156702644622
+2022-11-07,"2 wk flu hosp rate change","US","US","category","increase",0.200573227746219
+2022-11-07,"2 wk flu hosp rate change","49","Utah","category","increase",0.065624272608656
+2022-11-07,"2 wk flu hosp rate change","50","Vermont","category","increase",1.40458755737427e-11
+2022-11-07,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-11-07,"2 wk flu hosp rate change","51","Virginia","category","increase",0.176216655181777
+2022-11-07,"2 wk flu hosp rate change","53","Washington","category","increase",0.0119962519560612
+2022-11-07,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.0781428721000197
+2022-11-07,"2 wk flu hosp rate change","55","Wisconsin","category","increase",0.0169163083822014
+2022-11-07,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.0843480364008129
+2022-11-07,"2 wk flu hosp rate change","01","Alabama","category","stable",0.203895284590465
+2022-11-07,"2 wk flu hosp rate change","02","Alaska","category","stable",0.716548445983278
+2022-11-07,"2 wk flu hosp rate change","04","Arizona","category","stable",0.714531767058178
+2022-11-07,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.307053889244237
+2022-11-07,"2 wk flu hosp rate change","06","California","category","stable",0.941070803451545
+2022-11-07,"2 wk flu hosp rate change","08","Colorado","category","stable",0.899671829183879
+2022-11-07,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.607609091011315
+2022-11-07,"2 wk flu hosp rate change","10","Delaware","category","stable",0.838792816336534
+2022-11-07,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.461477173282489
+2022-11-07,"2 wk flu hosp rate change","12","Florida","category","stable",0.864259054590815
+2022-11-07,"2 wk flu hosp rate change","13","Georgia","category","stable",0.562662452994089
+2022-11-07,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.863646326158569
+2022-11-07,"2 wk flu hosp rate change","16","Idaho","category","stable",0.739730690966532
+2022-11-07,"2 wk flu hosp rate change","17","Illinois","category","stable",0.728919897262559
+2022-11-07,"2 wk flu hosp rate change","18","Indiana","category","stable",0.530880019165008
+2022-11-07,"2 wk flu hosp rate change","19","Iowa","category","stable",0.956376981235578
+2022-11-07,"2 wk flu hosp rate change","20","Kansas","category","stable",0.611475590585048
+2022-11-07,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.439682659728214
+2022-11-07,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.394309497447552
+2022-11-07,"2 wk flu hosp rate change","23","Maine","category","stable",0.992419225675773
+2022-11-07,"2 wk flu hosp rate change","24","Maryland","category","stable",0.504352017784447
+2022-11-07,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.928226998602784
+2022-11-07,"2 wk flu hosp rate change","26","Michigan","category","stable",0.944202272102017
+2022-11-07,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.527357769517607
+2022-11-07,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.2105019722023
+2022-11-07,"2 wk flu hosp rate change","29","Missouri","category","stable",0.737481179314124
+2022-11-07,"2 wk flu hosp rate change","30","Montana","category","stable",0.932764223855272
+2022-11-07,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.582387700374164
+2022-11-07,"2 wk flu hosp rate change","32","Nevada","category","stable",0.667847616936714
+2022-11-07,"2 wk flu hosp rate change","33","New Hampshire","category","stable",0.974371533168252
+2022-11-07,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.63158154377808
+2022-11-07,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.32089067586393
+2022-11-07,"2 wk flu hosp rate change","36","New York","category","stable",0.893604954405617
+2022-11-07,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.548712254479856
+2022-11-07,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.948994639642873
+2022-11-07,"2 wk flu hosp rate change","39","Ohio","category","stable",0.640907317554408
+2022-11-07,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.804835254789588
+2022-11-07,"2 wk flu hosp rate change","41","Oregon","category","stable",0.719089903150484
+2022-11-07,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.742124917469882
+2022-11-07,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.364512087068812
+2022-11-07,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.98963646257699
+2022-11-07,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.220333688379903
+2022-11-07,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.974993839554861
+2022-11-07,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.441775091285472
+2022-11-07,"2 wk flu hosp rate change","48","Texas","category","stable",0.631166856355796
+2022-11-07,"2 wk flu hosp rate change","US","US","category","stable",0.797028374785989
+2022-11-07,"2 wk flu hosp rate change","49","Utah","category","stable",0.933469099684385
+2022-11-07,"2 wk flu hosp rate change","50","Vermont","category","stable",0.999999999985954
+2022-11-07,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-11-07,"2 wk flu hosp rate change","51","Virginia","category","stable",0.412121371175028
+2022-11-07,"2 wk flu hosp rate change","53","Washington","category","stable",0.98800362307632
+2022-11-07,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.252583115433164
+2022-11-07,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.983083599275675
+2022-11-07,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.914924663581387
+2022-11-07,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.0524395847196373
+2022-11-07,"2 wk flu hosp rate change","04","Arizona","category","decrease",0.0179226436970523
+2022-11-07,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.126224832529237
+2022-11-07,"2 wk flu hosp rate change","06","California","category","decrease",0.00024688736452693
+2022-11-07,"2 wk flu hosp rate change","09","Connecticut","category","decrease",0.0584037553142632
+2022-11-07,"2 wk flu hosp rate change","11","District of Columbia","category","decrease",0.118535392066953
+2022-11-07,"2 wk flu hosp rate change","12","Florida","category","decrease",0.00743112802243933
+2022-11-07,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.131836929290356
+2022-11-07,"2 wk flu hosp rate change","17","Illinois","category","decrease",0.015516281204798
+2022-11-07,"2 wk flu hosp rate change","18","Indiana","category","decrease",0.08135006780563
+2022-11-07,"2 wk flu hosp rate change","20","Kansas","category","decrease",0.049080192853952
+2022-11-07,"2 wk flu hosp rate change","21","Kentucky","category","decrease",0.0668585150076774
+2022-11-07,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.112343121908628
+2022-11-07,"2 wk flu hosp rate change","24","Maryland","category","decrease",0.119554571773284
+2022-11-07,"2 wk flu hosp rate change","27","Minnesota","category","decrease",0.0801288015772974
+2022-11-07,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.0965315827163816
+2022-11-07,"2 wk flu hosp rate change","29","Missouri","category","decrease",0.0122295996311043
+2022-11-07,"2 wk flu hosp rate change","31","Nebraska","category","decrease",0.052108539796729
+2022-11-07,"2 wk flu hosp rate change","32","Nevada","category","decrease",0.0652603649368754
+2022-11-07,"2 wk flu hosp rate change","34","New Jersey","category","decrease",0.0487652615688212
+2022-11-07,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0753812886664316
+2022-11-07,"2 wk flu hosp rate change","37","North Carolina","category","decrease",0.0647116976480283
+2022-11-07,"2 wk flu hosp rate change","39","Ohio","category","decrease",0.0769508016125002
+2022-11-07,"2 wk flu hosp rate change","42","Pennsylvania","category","decrease",0.0324760069185322
+2022-11-07,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.109317659933901
+2022-11-07,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.075337663408967
+2022-11-07,"2 wk flu hosp rate change","47","Tennessee","category","decrease",0.0776649171711511
+2022-11-07,"2 wk flu hosp rate change","48","Texas","category","decrease",0.00800491016738207
+2022-11-07,"2 wk flu hosp rate change","US","US","category","decrease",8.26088631793174e-05
+2022-11-07,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.108973408361035
+2022-11-07,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.121820048154571
+2022-11-07,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.0408312309097308
+2022-11-07,"2 wk flu hosp rate change","05","Arkansas","category","large_decrease",0.14082141219171
+2022-11-07,"2 wk flu hosp rate change","13","Georgia","category","large_decrease",1.37290843310748e-08
+2022-11-07,"2 wk flu hosp rate change","18","Indiana","category","large_decrease",0.00370773358830847
+2022-11-07,"2 wk flu hosp rate change","21","Kentucky","category","large_decrease",0.0353012369680358
+2022-11-07,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.078762621296263
+2022-11-07,"2 wk flu hosp rate change","24","Maryland","category","large_decrease",0.00652260189761227
+2022-11-07,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.162415065410332
+2022-11-07,"2 wk flu hosp rate change","34","New Jersey","category","large_decrease",0.00456706205579124
+2022-11-07,"2 wk flu hosp rate change","35","New Mexico","category","large_decrease",0.0700219616710232
+2022-11-07,"2 wk flu hosp rate change","37","North Carolina","category","large_decrease",0.00507618822833636
+2022-11-07,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",0.0661573401400078
+2022-11-07,"2 wk flu hosp rate change","45","South Carolina","category","large_decrease",0.096182912886059
+2022-11-07,"2 wk flu hosp rate change","47","Tennessee","category","large_decrease",0.040170149877539
+2022-11-07,"2 wk flu hosp rate change","48","Texas","category","large_decrease",7.86559711846175e-05
+2022-11-07,"2 wk flu hosp rate change","51","Virginia","category","large_decrease",0.0636701843782252
+2022-11-07,"2 wk flu hosp rate change","54","West Virginia","category","large_decrease",0.222022176439001

--- a/data-experimental/UMass-trends_ensemble/2022-11-14-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-11-14-UMass-trends_ensemble.csv
@@ -1,0 +1,227 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-11-14,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.278193686494906
+2022-11-14,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.109936298062389
+2022-11-14,"2 wk flu hosp rate change","04","Arizona","category","large_increase",0.189968195312092
+2022-11-14,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.429672983275422
+2022-11-14,"2 wk flu hosp rate change","06","California","category","large_increase",0.0494777780141926
+2022-11-14,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0.0262221837117067
+2022-11-14,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",0.23405091444942
+2022-11-14,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0.0767534825684086
+2022-11-14,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",0.229826333533141
+2022-11-14,"2 wk flu hosp rate change","12","Florida","category","large_increase",0.0900322709219826
+2022-11-14,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.062805473623715
+2022-11-14,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",0.0556490539760003
+2022-11-14,"2 wk flu hosp rate change","16","Idaho","category","large_increase",0.141737007705542
+2022-11-14,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0.0171684335019018
+2022-11-14,"2 wk flu hosp rate change","18","Indiana","category","large_increase",0.149793809163285
+2022-11-14,"2 wk flu hosp rate change","19","Iowa","category","large_increase",0.00373091098450906
+2022-11-14,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.0899619822601515
+2022-11-14,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.394392290932175
+2022-11-14,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.261176629965349
+2022-11-14,"2 wk flu hosp rate change","23","Maine","category","large_increase",0.0101126393270901
+2022-11-14,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.199610673172051
+2022-11-14,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0.000271653685741557
+2022-11-14,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0.00119922260113703
+2022-11-14,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",0.399734845290663
+2022-11-14,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.395174391536123
+2022-11-14,"2 wk flu hosp rate change","29","Missouri","category","large_increase",0.0626149280902421
+2022-11-14,"2 wk flu hosp rate change","30","Montana","category","large_increase",0.0147806697182292
+2022-11-14,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.132496769875303
+2022-11-14,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.335300813684194
+2022-11-14,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0.000723436257004217
+2022-11-14,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",0.237898789803737
+2022-11-14,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.45500628651043
+2022-11-14,"2 wk flu hosp rate change","36","New York","category","large_increase",0.00246354418485417
+2022-11-14,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.276382720400322
+2022-11-14,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",0.00496675048064987
+2022-11-14,"2 wk flu hosp rate change","39","Ohio","category","large_increase",0.211398678102065
+2022-11-14,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.150082613088833
+2022-11-14,"2 wk flu hosp rate change","41","Oregon","category","large_increase",0.097658317189366
+2022-11-14,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",0.137463210363153
+2022-11-14,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.338925968896748
+2022-11-14,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",0.0205291512023612
+2022-11-14,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.338623405509265
+2022-11-14,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",0.00379352620458906
+2022-11-14,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.332645646114755
+2022-11-14,"2 wk flu hosp rate change","48","Texas","category","large_increase",0.176379543118146
+2022-11-14,"2 wk flu hosp rate change","US","US","category","large_increase",0.0117502370983369
+2022-11-14,"2 wk flu hosp rate change","49","Utah","category","large_increase",0.00353181550603088
+2022-11-14,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0
+2022-11-14,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-11-14,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.209397016581487
+2022-11-14,"2 wk flu hosp rate change","53","Washington","category","large_increase",0.00400610552723202
+2022-11-14,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.385994621362776
+2022-11-14,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",0.0175738014376408
+2022-11-14,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",0.00215425454058715
+2022-11-14,"2 wk flu hosp rate change","01","Alabama","category","increase",0.089577375884668
+2022-11-14,"2 wk flu hosp rate change","02","Alaska","category","increase",0.226905080170219
+2022-11-14,"2 wk flu hosp rate change","04","Arizona","category","increase",0.193028743909856
+2022-11-14,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.0805168518727102
+2022-11-14,"2 wk flu hosp rate change","06","California","category","increase",0.21733739045542
+2022-11-14,"2 wk flu hosp rate change","08","Colorado","category","increase",0.19558963126556
+2022-11-14,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.174598920562173
+2022-11-14,"2 wk flu hosp rate change","10","Delaware","category","increase",0.239198367523252
+2022-11-14,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.141052029718089
+2022-11-14,"2 wk flu hosp rate change","12","Florida","category","increase",0.219670406153847
+2022-11-14,"2 wk flu hosp rate change","13","Georgia","category","increase",0.234087968135174
+2022-11-14,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.194034349268421
+2022-11-14,"2 wk flu hosp rate change","16","Idaho","category","increase",0.169153983608411
+2022-11-14,"2 wk flu hosp rate change","17","Illinois","category","increase",0.18885830155376
+2022-11-14,"2 wk flu hosp rate change","18","Indiana","category","increase",0.180063307098456
+2022-11-14,"2 wk flu hosp rate change","19","Iowa","category","increase",0.119550893582934
+2022-11-14,"2 wk flu hosp rate change","20","Kansas","category","increase",0.217679793241633
+2022-11-14,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.102395900404976
+2022-11-14,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.129821884624393
+2022-11-14,"2 wk flu hosp rate change","23","Maine","category","increase",0.225174840184529
+2022-11-14,"2 wk flu hosp rate change","24","Maryland","category","increase",0.1479328106605
+2022-11-14,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0.123093074813972
+2022-11-14,"2 wk flu hosp rate change","26","Michigan","category","increase",0.116449716136627
+2022-11-14,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.127226660231411
+2022-11-14,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.0750178754294237
+2022-11-14,"2 wk flu hosp rate change","29","Missouri","category","increase",0.251779668032619
+2022-11-14,"2 wk flu hosp rate change","30","Montana","category","increase",0.158544031736061
+2022-11-14,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.155889943719732
+2022-11-14,"2 wk flu hosp rate change","32","Nevada","category","increase",0.119125939735636
+2022-11-14,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0.0845316317039059
+2022-11-14,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.204039034268698
+2022-11-14,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.0951831041974566
+2022-11-14,"2 wk flu hosp rate change","36","New York","category","increase",0.176248587173311
+2022-11-14,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.24965473044779
+2022-11-14,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.0947683719969049
+2022-11-14,"2 wk flu hosp rate change","39","Ohio","category","increase",0.142040751187662
+2022-11-14,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.154541401538024
+2022-11-14,"2 wk flu hosp rate change","41","Oregon","category","increase",0.193198278808718
+2022-11-14,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.176051175463595
+2022-11-14,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.143772889573118
+2022-11-14,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.25750038593921
+2022-11-14,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.109196732287269
+2022-11-14,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.0954210486050492
+2022-11-14,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.151945680069244
+2022-11-14,"2 wk flu hosp rate change","48","Texas","category","increase",0.207803319770475
+2022-11-14,"2 wk flu hosp rate change","US","US","category","increase",0.252422224008743
+2022-11-14,"2 wk flu hosp rate change","49","Utah","category","increase",0.138036357189051
+2022-11-14,"2 wk flu hosp rate change","50","Vermont","category","increase",2.1094237467878e-13
+2022-11-14,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-11-14,"2 wk flu hosp rate change","51","Virginia","category","increase",0.165743123544963
+2022-11-14,"2 wk flu hosp rate change","53","Washington","category","increase",0.120129429341103
+2022-11-14,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.0474800889750741
+2022-11-14,"2 wk flu hosp rate change","55","Wisconsin","category","increase",0.231354812247216
+2022-11-14,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.111923494789084
+2022-11-14,"2 wk flu hosp rate change","01","Alabama","category","stable",0.315516850966397
+2022-11-14,"2 wk flu hosp rate change","02","Alaska","category","stable",0.663158621767392
+2022-11-14,"2 wk flu hosp rate change","04","Arizona","category","stable",0.517234662036557
+2022-11-14,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.197646580234989
+2022-11-14,"2 wk flu hosp rate change","06","California","category","stable",0.707136022651963
+2022-11-14,"2 wk flu hosp rate change","08","Colorado","category","stable",0.778188185022733
+2022-11-14,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.475598448214943
+2022-11-14,"2 wk flu hosp rate change","10","Delaware","category","stable",0.684048149908339
+2022-11-14,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.389216155193882
+2022-11-14,"2 wk flu hosp rate change","12","Florida","category","stable",0.671989173826881
+2022-11-14,"2 wk flu hosp rate change","13","Georgia","category","stable",0.616497249103541
+2022-11-14,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.718296642523151
+2022-11-14,"2 wk flu hosp rate change","16","Idaho","category","stable",0.689109008686047
+2022-11-14,"2 wk flu hosp rate change","17","Illinois","category","stable",0.6756372917403
+2022-11-14,"2 wk flu hosp rate change","18","Indiana","category","stable",0.477130024763793
+2022-11-14,"2 wk flu hosp rate change","19","Iowa","category","stable",0.876718195432557
+2022-11-14,"2 wk flu hosp rate change","20","Kansas","category","stable",0.568886708803817
+2022-11-14,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.273239826188891
+2022-11-14,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.37994765722516
+2022-11-14,"2 wk flu hosp rate change","23","Maine","category","stable",0.764712520488381
+2022-11-14,"2 wk flu hosp rate change","24","Maryland","category","stable",0.415054057965795
+2022-11-14,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.876635271500286
+2022-11-14,"2 wk flu hosp rate change","26","Michigan","category","stable",0.882350229878172
+2022-11-14,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.347359496628464
+2022-11-14,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.198085132541188
+2022-11-14,"2 wk flu hosp rate change","29","Missouri","category","stable",0.639533825486921
+2022-11-14,"2 wk flu hosp rate change","30","Montana","category","stable",0.82667529854571
+2022-11-14,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.557143790277039
+2022-11-14,"2 wk flu hosp rate change","32","Nevada","category","stable",0.439906171260872
+2022-11-14,"2 wk flu hosp rate change","33","New Hampshire","category","stable",0.91474493203909
+2022-11-14,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.459577889854165
+2022-11-14,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.213669202544039
+2022-11-14,"2 wk flu hosp rate change","36","New York","category","stable",0.806501511879172
+2022-11-14,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.371402866822508
+2022-11-14,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.900264877522445
+2022-11-14,"2 wk flu hosp rate change","39","Ohio","category","stable",0.485436410597734
+2022-11-14,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.450060532076357
+2022-11-14,"2 wk flu hosp rate change","41","Oregon","category","stable",0.577983646198778
+2022-11-14,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.465499092792778
+2022-11-14,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.309898572162804
+2022-11-14,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.721970462858429
+2022-11-14,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.297155964194658
+2022-11-14,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.900785425190362
+2022-11-14,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.317004476983475
+2022-11-14,"2 wk flu hosp rate change","48","Texas","category","stable",0.478082994079818
+2022-11-14,"2 wk flu hosp rate change","US","US","category","stable",0.732524552697104
+2022-11-14,"2 wk flu hosp rate change","49","Utah","category","stable",0.858431827304918
+2022-11-14,"2 wk flu hosp rate change","50","Vermont","category","stable",0.999999999999789
+2022-11-14,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-11-14,"2 wk flu hosp rate change","51","Virginia","category","stable",0.530671401641287
+2022-11-14,"2 wk flu hosp rate change","53","Washington","category","stable",0.868719193398885
+2022-11-14,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.175203657404718
+2022-11-14,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.751071386315143
+2022-11-14,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.885922250670329
+2022-11-14,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.0914630305430755
+2022-11-14,"2 wk flu hosp rate change","04","Arizona","category","decrease",0.0991460635312923
+2022-11-14,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.0808574054008555
+2022-11-14,"2 wk flu hosp rate change","06","California","category","decrease",0.025846445757664
+2022-11-14,"2 wk flu hosp rate change","09","Connecticut","category","decrease",0.115751716773464
+2022-11-14,"2 wk flu hosp rate change","11","District of Columbia","category","decrease",0.215978795405975
+2022-11-14,"2 wk flu hosp rate change","12","Florida","category","decrease",0.0180754624013648
+2022-11-14,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.0864013988967959
+2022-11-14,"2 wk flu hosp rate change","15","Hawaii","category","decrease",0.0320199542324276
+2022-11-14,"2 wk flu hosp rate change","17","Illinois","category","decrease",0.118323058415363
+2022-11-14,"2 wk flu hosp rate change","18","Indiana","category","decrease",0.193012858974466
+2022-11-14,"2 wk flu hosp rate change","20","Kansas","category","decrease",0.123471515694399
+2022-11-14,"2 wk flu hosp rate change","21","Kentucky","category","decrease",0.0977419457565069
+2022-11-14,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.131074496981632
+2022-11-14,"2 wk flu hosp rate change","24","Maryland","category","decrease",0.155776874886797
+2022-11-14,"2 wk flu hosp rate change","26","Michigan","category","decrease",8.31384064392394e-07
+2022-11-14,"2 wk flu hosp rate change","27","Minnesota","category","decrease",0.0756503488680338
+2022-11-14,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.0791776766504207
+2022-11-14,"2 wk flu hosp rate change","29","Missouri","category","decrease",0.0460715783902187
+2022-11-14,"2 wk flu hosp rate change","31","Nebraska","category","decrease",0.154469496127926
+2022-11-14,"2 wk flu hosp rate change","32","Nevada","category","decrease",0.0747510574980507
+2022-11-14,"2 wk flu hosp rate change","34","New Jersey","category","decrease",0.0707486001216074
+2022-11-14,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0864004292193317
+2022-11-14,"2 wk flu hosp rate change","36","New York","category","decrease",0.0147863567626627
+2022-11-14,"2 wk flu hosp rate change","37","North Carolina","category","decrease",0.089264836693363
+2022-11-14,"2 wk flu hosp rate change","39","Ohio","category","decrease",0.149653311724377
+2022-11-14,"2 wk flu hosp rate change","40","Oklahoma","category","decrease",0.245218461235389
+2022-11-14,"2 wk flu hosp rate change","41","Oregon","category","decrease",0.131159757803138
+2022-11-14,"2 wk flu hosp rate change","42","Pennsylvania","category","decrease",0.178426116669406
+2022-11-14,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.09765797482122
+2022-11-14,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.138576366575622
+2022-11-14,"2 wk flu hosp rate change","47","Tennessee","category","decrease",0.106739829999381
+2022-11-14,"2 wk flu hosp rate change","48","Texas","category","decrease",0.137407640647065
+2022-11-14,"2 wk flu hosp rate change","US","US","category","decrease",0.00330034534436792
+2022-11-14,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.0851555047236005
+2022-11-14,"2 wk flu hosp rate change","53","Washington","category","decrease",0.00714527173277965
+2022-11-14,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.08276545914019
+2022-11-14,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.225249056110953
+2022-11-14,"2 wk flu hosp rate change","04","Arizona","category","large_decrease",0.000622335210202809
+2022-11-14,"2 wk flu hosp rate change","05","Arkansas","category","large_decrease",0.211306179216023
+2022-11-14,"2 wk flu hosp rate change","06","California","category","large_decrease",0.00020236312075997
+2022-11-14,"2 wk flu hosp rate change","11","District of Columbia","category","large_decrease",0.0239266861489131
+2022-11-14,"2 wk flu hosp rate change","12","Florida","category","large_decrease",0.000232686695924035
+2022-11-14,"2 wk flu hosp rate change","13","Georgia","category","large_decrease",0.000207910240774218
+2022-11-14,"2 wk flu hosp rate change","17","Illinois","category","large_decrease",1.29147886755285e-05
+2022-11-14,"2 wk flu hosp rate change","21","Kentucky","category","large_decrease",0.132230036717451
+2022-11-14,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.0979793312034658
+2022-11-14,"2 wk flu hosp rate change","24","Maryland","category","large_decrease",0.0816255833148575
+2022-11-14,"2 wk flu hosp rate change","27","Minnesota","category","large_decrease",0.0500286489814276
+2022-11-14,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.252544923842844
+2022-11-14,"2 wk flu hosp rate change","32","Nevada","category","large_decrease",0.0309160178212477
+2022-11-14,"2 wk flu hosp rate change","34","New Jersey","category","large_decrease",0.0277356859517927
+2022-11-14,"2 wk flu hosp rate change","35","New Mexico","category","large_decrease",0.149740977528743
+2022-11-14,"2 wk flu hosp rate change","37","North Carolina","category","large_decrease",0.0132948456360176
+2022-11-14,"2 wk flu hosp rate change","39","Ohio","category","large_decrease",0.0114708483881626
+2022-11-14,"2 wk flu hosp rate change","40","Oklahoma","category","large_decrease",9.69920613966964e-05
+2022-11-14,"2 wk flu hosp rate change","42","Pennsylvania","category","large_decrease",0.0425604047110679
+2022-11-14,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",0.109744594546109
+2022-11-14,"2 wk flu hosp rate change","45","South Carolina","category","large_decrease",0.116447531433186
+2022-11-14,"2 wk flu hosp rate change","47","Tennessee","category","large_decrease",0.0916643668331451
+2022-11-14,"2 wk flu hosp rate change","48","Texas","category","large_decrease",0.000326502384495471
+2022-11-14,"2 wk flu hosp rate change","US","US","category","large_decrease",2.64085144833337e-06
+2022-11-14,"2 wk flu hosp rate change","51","Virginia","category","large_decrease",0.00903295350866334
+2022-11-14,"2 wk flu hosp rate change","54","West Virginia","category","large_decrease",0.308556173117242

--- a/data-experimental/UMass-trends_ensemble/2022-11-21-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-11-21-UMass-trends_ensemble.csv
@@ -1,0 +1,244 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-11-21,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.212276369814785
+2022-11-21,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.150077780076981
+2022-11-21,"2 wk flu hosp rate change","04","Arizona","category","large_increase",0.336480202416099
+2022-11-21,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.434098501783648
+2022-11-21,"2 wk flu hosp rate change","06","California","category","large_increase",0.260643361695437
+2022-11-21,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0.199609350579126
+2022-11-21,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",0.361869013583225
+2022-11-21,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0.375308579371138
+2022-11-21,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",0.21780681695046
+2022-11-21,"2 wk flu hosp rate change","12","Florida","category","large_increase",0.0499908783613484
+2022-11-21,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.0326611854653224
+2022-11-21,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",0.0420427563553563
+2022-11-21,"2 wk flu hosp rate change","16","Idaho","category","large_increase",0.328866542760656
+2022-11-21,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0.207634278013454
+2022-11-21,"2 wk flu hosp rate change","18","Indiana","category","large_increase",0.311023841587753
+2022-11-21,"2 wk flu hosp rate change","19","Iowa","category","large_increase",0.0101962693354726
+2022-11-21,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.264708528798789
+2022-11-21,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.489744637371597
+2022-11-21,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.172167456543667
+2022-11-21,"2 wk flu hosp rate change","23","Maine","category","large_increase",0.014336963824398
+2022-11-21,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.203305758574222
+2022-11-21,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0.0238416682172941
+2022-11-21,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0.135801768079412
+2022-11-21,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",0.443368773104435
+2022-11-21,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.337700398780334
+2022-11-21,"2 wk flu hosp rate change","29","Missouri","category","large_increase",0.157625296541118
+2022-11-21,"2 wk flu hosp rate change","30","Montana","category","large_increase",0.049149556596406
+2022-11-21,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.325711968754012
+2022-11-21,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.472963907272966
+2022-11-21,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0.00180499731167205
+2022-11-21,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",0.217059189126963
+2022-11-21,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.412202179199145
+2022-11-21,"2 wk flu hosp rate change","36","New York","category","large_increase",0.0715618441725329
+2022-11-21,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.230897908285621
+2022-11-21,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",0.00616703298941157
+2022-11-21,"2 wk flu hosp rate change","39","Ohio","category","large_increase",0.248244809851783
+2022-11-21,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.299980664545409
+2022-11-21,"2 wk flu hosp rate change","41","Oregon","category","large_increase",0.332158974593575
+2022-11-21,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",0.166362563058814
+2022-11-21,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.123825368902453
+2022-11-21,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",0.00236310524997019
+2022-11-21,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.226050287633529
+2022-11-21,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",0.158828633000956
+2022-11-21,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.328160055021207
+2022-11-21,"2 wk flu hosp rate change","48","Texas","category","large_increase",0.0635961668345129
+2022-11-21,"2 wk flu hosp rate change","US","US","category","large_increase",0.0210527937800766
+2022-11-21,"2 wk flu hosp rate change","49","Utah","category","large_increase",0.000175157684124905
+2022-11-21,"2 wk flu hosp rate change","50","Vermont","category","large_increase",1.11022302462516e-14
+2022-11-21,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-11-21,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.146757958254483
+2022-11-21,"2 wk flu hosp rate change","53","Washington","category","large_increase",0.255188079411956
+2022-11-21,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.389620906044693
+2022-11-21,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",0.149633345536091
+2022-11-21,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",0.224005515518127
+2022-11-21,"2 wk flu hosp rate change","01","Alabama","category","increase",0.0778029847883365
+2022-11-21,"2 wk flu hosp rate change","02","Alaska","category","increase",0.141278173279089
+2022-11-21,"2 wk flu hosp rate change","04","Arizona","category","increase",0.154657720793609
+2022-11-21,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.0932666528443301
+2022-11-21,"2 wk flu hosp rate change","06","California","category","increase",0.271967965012251
+2022-11-21,"2 wk flu hosp rate change","08","Colorado","category","increase",0.167019356573586
+2022-11-21,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.114092848626536
+2022-11-21,"2 wk flu hosp rate change","10","Delaware","category","increase",0.0983293058432416
+2022-11-21,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.168361848687396
+2022-11-21,"2 wk flu hosp rate change","12","Florida","category","increase",0.167282499641428
+2022-11-21,"2 wk flu hosp rate change","13","Georgia","category","increase",0.19105027071177
+2022-11-21,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.116728748093627
+2022-11-21,"2 wk flu hosp rate change","16","Idaho","category","increase",0.129875786627653
+2022-11-21,"2 wk flu hosp rate change","17","Illinois","category","increase",0.239436325307387
+2022-11-21,"2 wk flu hosp rate change","18","Indiana","category","increase",0.128905095705041
+2022-11-21,"2 wk flu hosp rate change","19","Iowa","category","increase",0.177551435548008
+2022-11-21,"2 wk flu hosp rate change","20","Kansas","category","increase",0.169762915468366
+2022-11-21,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.159974760209147
+2022-11-21,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.100524614931337
+2022-11-21,"2 wk flu hosp rate change","23","Maine","category","increase",0.187119478798049
+2022-11-21,"2 wk flu hosp rate change","24","Maryland","category","increase",0.165837078297268
+2022-11-21,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0.271737799375684
+2022-11-21,"2 wk flu hosp rate change","26","Michigan","category","increase",0.227495553548535
+2022-11-21,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.159487803169503
+2022-11-21,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.0627841394682457
+2022-11-21,"2 wk flu hosp rate change","29","Missouri","category","increase",0.259152919467506
+2022-11-21,"2 wk flu hosp rate change","30","Montana","category","increase",0.267080527364008
+2022-11-21,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.113091772104177
+2022-11-21,"2 wk flu hosp rate change","32","Nevada","category","increase",0.170901274459152
+2022-11-21,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0.116152455018509
+2022-11-21,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.178565675798563
+2022-11-21,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.0771289462740445
+2022-11-21,"2 wk flu hosp rate change","36","New York","category","increase",0.204803940291408
+2022-11-21,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.2046706878393
+2022-11-21,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.116913564348243
+2022-11-21,"2 wk flu hosp rate change","39","Ohio","category","increase",0.192210390295527
+2022-11-21,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.164051713213727
+2022-11-21,"2 wk flu hosp rate change","41","Oregon","category","increase",0.136300802504008
+2022-11-21,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.215253751694264
+2022-11-21,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.117053743905172
+2022-11-21,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.06244435029111
+2022-11-21,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.146055841148197
+2022-11-21,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.221504280543661
+2022-11-21,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.110764320341855
+2022-11-21,"2 wk flu hosp rate change","48","Texas","category","increase",0.192740406069287
+2022-11-21,"2 wk flu hosp rate change","US","US","category","increase",0.269158752635488
+2022-11-21,"2 wk flu hosp rate change","49","Utah","category","increase",0.0356294976202824
+2022-11-21,"2 wk flu hosp rate change","50","Vermont","category","increase",2.17363680552474e-05
+2022-11-21,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-11-21,"2 wk flu hosp rate change","51","Virginia","category","increase",0.171591760316143
+2022-11-21,"2 wk flu hosp rate change","53","Washington","category","increase",0.221969516178312
+2022-11-21,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.0351364581186735
+2022-11-21,"2 wk flu hosp rate change","55","Wisconsin","category","increase",0.230303959614728
+2022-11-21,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.139131631659505
+2022-11-21,"2 wk flu hosp rate change","01","Alabama","category","stable",0.281457776376967
+2022-11-21,"2 wk flu hosp rate change","02","Alaska","category","stable",0.500752278015463
+2022-11-21,"2 wk flu hosp rate change","04","Arizona","category","stable",0.447435757063863
+2022-11-21,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.193742448450782
+2022-11-21,"2 wk flu hosp rate change","06","California","category","stable",0.456643209616848
+2022-11-21,"2 wk flu hosp rate change","08","Colorado","category","stable",0.414879840254151
+2022-11-21,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.305225228862704
+2022-11-21,"2 wk flu hosp rate change","10","Delaware","category","stable",0.327338242341879
+2022-11-21,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.363171636018717
+2022-11-21,"2 wk flu hosp rate change","12","Florida","category","stable",0.709558250602491
+2022-11-21,"2 wk flu hosp rate change","13","Georgia","category","stable",0.644732192996623
+2022-11-21,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.841228495551017
+2022-11-21,"2 wk flu hosp rate change","16","Idaho","category","stable",0.369968921698837
+2022-11-21,"2 wk flu hosp rate change","17","Illinois","category","stable",0.51592580985124
+2022-11-21,"2 wk flu hosp rate change","18","Indiana","category","stable",0.360130571249731
+2022-11-21,"2 wk flu hosp rate change","19","Iowa","category","stable",0.812252295116519
+2022-11-21,"2 wk flu hosp rate change","20","Kansas","category","stable",0.434934460990358
+2022-11-21,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.142354609285282
+2022-11-21,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.466319665880897
+2022-11-21,"2 wk flu hosp rate change","23","Maine","category","stable",0.798543557377553
+2022-11-21,"2 wk flu hosp rate change","24","Maryland","category","stable",0.430398255339515
+2022-11-21,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.703677354952782
+2022-11-21,"2 wk flu hosp rate change","26","Michigan","category","stable",0.576859453659608
+2022-11-21,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.209115105780424
+2022-11-21,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.20286331853229
+2022-11-21,"2 wk flu hosp rate change","29","Missouri","category","stable",0.53313509477717
+2022-11-21,"2 wk flu hosp rate change","30","Montana","category","stable",0.683769916039586
+2022-11-21,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.361202925015298
+2022-11-21,"2 wk flu hosp rate change","32","Nevada","category","stable",0.264199236367382
+2022-11-21,"2 wk flu hosp rate change","33","New Hampshire","category","stable",0.882042547669819
+2022-11-21,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.443036402929761
+2022-11-21,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.164204267462523
+2022-11-21,"2 wk flu hosp rate change","36","New York","category","stable",0.684661353044032
+2022-11-21,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.440121041981694
+2022-11-21,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.876919402662345
+2022-11-21,"2 wk flu hosp rate change","39","Ohio","category","stable",0.402837050263284
+2022-11-21,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.385964051215704
+2022-11-21,"2 wk flu hosp rate change","41","Oregon","category","stable",0.408796582915083
+2022-11-21,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.430408088404829
+2022-11-21,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.488336549656557
+2022-11-21,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.93519254445892
+2022-11-21,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.317057928785661
+2022-11-21,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.519745236360865
+2022-11-21,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.330718981906872
+2022-11-21,"2 wk flu hosp rate change","48","Texas","category","stable",0.622759126264254
+2022-11-21,"2 wk flu hosp rate change","US","US","category","stable",0.708923240918157
+2022-11-21,"2 wk flu hosp rate change","49","Utah","category","stable",0.964195344695593
+2022-11-21,"2 wk flu hosp rate change","50","Vermont","category","stable",0.999978263631934
+2022-11-21,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-11-21,"2 wk flu hosp rate change","51","Virginia","category","stable",0.45454590004685
+2022-11-21,"2 wk flu hosp rate change","53","Washington","category","stable",0.503899801458773
+2022-11-21,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.179819303897623
+2022-11-21,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.554995901235694
+2022-11-21,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.52148754093232
+2022-11-21,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.161431405460114
+2022-11-21,"2 wk flu hosp rate change","02","Alaska","category","decrease",0.207891768628467
+2022-11-21,"2 wk flu hosp rate change","04","Arizona","category","decrease",0.039885556910583
+2022-11-21,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.0837486022017629
+2022-11-21,"2 wk flu hosp rate change","06","California","category","decrease",0.0101220418221183
+2022-11-21,"2 wk flu hosp rate change","08","Colorado","category","decrease",0.218491452593137
+2022-11-21,"2 wk flu hosp rate change","09","Connecticut","category","decrease",0.105753836618192
+2022-11-21,"2 wk flu hosp rate change","10","Delaware","category","decrease",0.118781949009857
+2022-11-21,"2 wk flu hosp rate change","11","District of Columbia","category","decrease",0.250659698343427
+2022-11-21,"2 wk flu hosp rate change","12","Florida","category","decrease",0.0726213359282106
+2022-11-21,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.131556350826284
+2022-11-21,"2 wk flu hosp rate change","16","Idaho","category","decrease",0.102694401697404
+2022-11-21,"2 wk flu hosp rate change","17","Illinois","category","decrease",0.0349485029050979
+2022-11-21,"2 wk flu hosp rate change","18","Indiana","category","decrease",0.121004691603165
+2022-11-21,"2 wk flu hosp rate change","19","Iowa","category","decrease",0
+2022-11-21,"2 wk flu hosp rate change","20","Kansas","category","decrease",0.125187749391764
+2022-11-21,"2 wk flu hosp rate change","21","Kentucky","category","decrease",0.0673865982578944
+2022-11-21,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.140009728249457
+2022-11-21,"2 wk flu hosp rate change","24","Maryland","category","decrease",0.157942733104822
+2022-11-21,"2 wk flu hosp rate change","25","Massachusetts","category","decrease",0.000743177454240191
+2022-11-21,"2 wk flu hosp rate change","26","Michigan","category","decrease",0.0598432247124446
+2022-11-21,"2 wk flu hosp rate change","27","Minnesota","category","decrease",0.0808654884103775
+2022-11-21,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.0793432139831524
+2022-11-21,"2 wk flu hosp rate change","29","Missouri","category","decrease",0.0447985181184905
+2022-11-21,"2 wk flu hosp rate change","31","Nebraska","category","decrease",0.163472454622005
+2022-11-21,"2 wk flu hosp rate change","32","Nevada","category","decrease",0.0540894573756703
+2022-11-21,"2 wk flu hosp rate change","34","New Jersey","category","decrease",0.115261997306171
+2022-11-21,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0764679869149155
+2022-11-21,"2 wk flu hosp rate change","36","New York","category","decrease",0.0387010186293009
+2022-11-21,"2 wk flu hosp rate change","37","North Carolina","category","decrease",0.0896461372478073
+2022-11-21,"2 wk flu hosp rate change","39","Ohio","category","decrease",0.127598888841903
+2022-11-21,"2 wk flu hosp rate change","40","Oklahoma","category","decrease",0.0875716145471904
+2022-11-21,"2 wk flu hosp rate change","41","Oregon","category","decrease",0.0769630491689206
+2022-11-21,"2 wk flu hosp rate change","42","Pennsylvania","category","decrease",0.160716267227377
+2022-11-21,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.237396388783024
+2022-11-21,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.148570415605353
+2022-11-21,"2 wk flu hosp rate change","46","South Dakota","category","decrease",0.0999218500945184
+2022-11-21,"2 wk flu hosp rate change","47","Tennessee","category","decrease",0.124611984585653
+2022-11-21,"2 wk flu hosp rate change","48","Texas","category","decrease",0.115502762170873
+2022-11-21,"2 wk flu hosp rate change","US","US","category","decrease",0.000864858644616201
+2022-11-21,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.169288166878889
+2022-11-21,"2 wk flu hosp rate change","53","Washington","category","decrease",0.0181615435724583
+2022-11-21,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.0803167595035754
+2022-11-21,"2 wk flu hosp rate change","55","Wisconsin","category","decrease",0.065066793613487
+2022-11-21,"2 wk flu hosp rate change","56","Wyoming","category","decrease",0.090859881832078
+2022-11-21,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.267031463559797
+2022-11-21,"2 wk flu hosp rate change","04","Arizona","category","large_decrease",0.0215407628158463
+2022-11-21,"2 wk flu hosp rate change","05","Arkansas","category","large_decrease",0.195143794719477
+2022-11-21,"2 wk flu hosp rate change","06","California","category","large_decrease",0.00062342185334567
+2022-11-21,"2 wk flu hosp rate change","09","Connecticut","category","large_decrease",0.113059072309344
+2022-11-21,"2 wk flu hosp rate change","10","Delaware","category","large_decrease",0.0802419234338845
+2022-11-21,"2 wk flu hosp rate change","12","Florida","category","large_decrease",0.00054703546652207
+2022-11-21,"2 wk flu hosp rate change","16","Idaho","category","large_decrease",0.0685943472154495
+2022-11-21,"2 wk flu hosp rate change","17","Illinois","category","large_decrease",0.00205508392282099
+2022-11-21,"2 wk flu hosp rate change","18","Indiana","category","large_decrease",0.0789357998543104
+2022-11-21,"2 wk flu hosp rate change","20","Kansas","category","large_decrease",0.00540634535072334
+2022-11-21,"2 wk flu hosp rate change","21","Kentucky","category","large_decrease",0.14053939487608
+2022-11-21,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.120978534394642
+2022-11-21,"2 wk flu hosp rate change","24","Maryland","category","large_decrease",0.0425161746841727
+2022-11-21,"2 wk flu hosp rate change","27","Minnesota","category","large_decrease",0.107162829535261
+2022-11-21,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.317308929235977
+2022-11-21,"2 wk flu hosp rate change","29","Missouri","category","large_decrease",0.00528817109571562
+2022-11-21,"2 wk flu hosp rate change","31","Nebraska","category","large_decrease",0.0365208795045087
+2022-11-21,"2 wk flu hosp rate change","32","Nevada","category","large_decrease",0.0378461245248307
+2022-11-21,"2 wk flu hosp rate change","34","New Jersey","category","large_decrease",0.0460767348385429
+2022-11-21,"2 wk flu hosp rate change","35","New Mexico","category","large_decrease",0.269996620149371
+2022-11-21,"2 wk flu hosp rate change","36","New York","category","large_decrease",0.000271843862726197
+2022-11-21,"2 wk flu hosp rate change","37","North Carolina","category","large_decrease",0.0346642246455778
+2022-11-21,"2 wk flu hosp rate change","39","Ohio","category","large_decrease",0.0291088607475025
+2022-11-21,"2 wk flu hosp rate change","40","Oklahoma","category","large_decrease",0.0624319564779698
+2022-11-21,"2 wk flu hosp rate change","41","Oregon","category","large_decrease",0.0457805908184136
+2022-11-21,"2 wk flu hosp rate change","42","Pennsylvania","category","large_decrease",0.0272593296147159
+2022-11-21,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",0.0333879487527937
+2022-11-21,"2 wk flu hosp rate change","45","South Carolina","category","large_decrease",0.162265526827259
+2022-11-21,"2 wk flu hosp rate change","47","Tennessee","category","large_decrease",0.105744658144413
+2022-11-21,"2 wk flu hosp rate change","48","Texas","category","large_decrease",0.00540153866107313
+2022-11-21,"2 wk flu hosp rate change","US","US","category","large_decrease",3.5402166235328e-07
+2022-11-21,"2 wk flu hosp rate change","51","Virginia","category","large_decrease",0.0578162145036347
+2022-11-21,"2 wk flu hosp rate change","53","Washington","category","large_decrease",0.000781059378501023
+2022-11-21,"2 wk flu hosp rate change","54","West Virginia","category","large_decrease",0.315106572435435
+2022-11-21,"2 wk flu hosp rate change","56","Wyoming","category","large_decrease",0.0245154300579689

--- a/data-experimental/UMass-trends_ensemble/2022-11-28-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-11-28-UMass-trends_ensemble.csv
@@ -1,0 +1,256 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-11-28,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.12529317549592
+2022-11-28,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.277980736037663
+2022-11-28,"2 wk flu hosp rate change","04","Arizona","category","large_increase",0.41458394001294
+2022-11-28,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.585721659767224
+2022-11-28,"2 wk flu hosp rate change","06","California","category","large_increase",0.393580992890919
+2022-11-28,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0.255895030044718
+2022-11-28,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",0.420496243248816
+2022-11-28,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0.359540350079866
+2022-11-28,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",0.36818734099001
+2022-11-28,"2 wk flu hosp rate change","12","Florida","category","large_increase",0.161195423573894
+2022-11-28,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.0421709181164871
+2022-11-28,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",0.08989907515614
+2022-11-28,"2 wk flu hosp rate change","16","Idaho","category","large_increase",0.444851816455346
+2022-11-28,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0.434550966524879
+2022-11-28,"2 wk flu hosp rate change","18","Indiana","category","large_increase",0.42981665077732
+2022-11-28,"2 wk flu hosp rate change","19","Iowa","category","large_increase",0.26957926158423
+2022-11-28,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.397592047873593
+2022-11-28,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.503235901908875
+2022-11-28,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.228353653579561
+2022-11-28,"2 wk flu hosp rate change","23","Maine","category","large_increase",0.183348613216756
+2022-11-28,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.259029873137856
+2022-11-28,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0.26066874814875
+2022-11-28,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0.206188095323999
+2022-11-28,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",0.411651962002537
+2022-11-28,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.291418112059553
+2022-11-28,"2 wk flu hosp rate change","29","Missouri","category","large_increase",0.541536152100698
+2022-11-28,"2 wk flu hosp rate change","30","Montana","category","large_increase",0.304488066466194
+2022-11-28,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.340946478944668
+2022-11-28,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.325470494896665
+2022-11-28,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0.0120207132484591
+2022-11-28,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",0.316534258324581
+2022-11-28,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.533899200259701
+2022-11-28,"2 wk flu hosp rate change","36","New York","category","large_increase",0.2129854280244
+2022-11-28,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.408243569020306
+2022-11-28,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",0.0543293513952805
+2022-11-28,"2 wk flu hosp rate change","39","Ohio","category","large_increase",0.282686838062926
+2022-11-28,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.489085684015349
+2022-11-28,"2 wk flu hosp rate change","41","Oregon","category","large_increase",0.425904071166225
+2022-11-28,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",0.309853024391993
+2022-11-28,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.00774660743697786
+2022-11-28,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",0.0251688974863836
+2022-11-28,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.195065660408021
+2022-11-28,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",0.241945472680796
+2022-11-28,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.396975753677997
+2022-11-28,"2 wk flu hosp rate change","48","Texas","category","large_increase",0.0102310505703928
+2022-11-28,"2 wk flu hosp rate change","US","US","category","large_increase",0.227490188990777
+2022-11-28,"2 wk flu hosp rate change","49","Utah","category","large_increase",0.10801821044182
+2022-11-28,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0.0585383551720237
+2022-11-28,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-11-28,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.200020563570923
+2022-11-28,"2 wk flu hosp rate change","53","Washington","category","large_increase",0.527715442339747
+2022-11-28,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.422111342444768
+2022-11-28,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",0.325700319096258
+2022-11-28,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",0.115064300573863
+2022-11-28,"2 wk flu hosp rate change","01","Alabama","category","increase",0.148774555322337
+2022-11-28,"2 wk flu hosp rate change","02","Alaska","category","increase",0.129327088949038
+2022-11-28,"2 wk flu hosp rate change","04","Arizona","category","increase",0.150563512699008
+2022-11-28,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.113929967234576
+2022-11-28,"2 wk flu hosp rate change","06","California","category","increase",0.275855825165299
+2022-11-28,"2 wk flu hosp rate change","08","Colorado","category","increase",0.107005031703914
+2022-11-28,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.0845340093671852
+2022-11-28,"2 wk flu hosp rate change","10","Delaware","category","increase",0.0850478537389046
+2022-11-28,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.114273272055999
+2022-11-28,"2 wk flu hosp rate change","12","Florida","category","increase",0.245702015509347
+2022-11-28,"2 wk flu hosp rate change","13","Georgia","category","increase",0.173338747033117
+2022-11-28,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.171922842492875
+2022-11-28,"2 wk flu hosp rate change","16","Idaho","category","increase",0.139357598614839
+2022-11-28,"2 wk flu hosp rate change","17","Illinois","category","increase",0.184067730506181
+2022-11-28,"2 wk flu hosp rate change","18","Indiana","category","increase",0.122225814852032
+2022-11-28,"2 wk flu hosp rate change","19","Iowa","category","increase",0.137671370445419
+2022-11-28,"2 wk flu hosp rate change","20","Kansas","category","increase",0.105720362742338
+2022-11-28,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.165341910931543
+2022-11-28,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.156396749580865
+2022-11-28,"2 wk flu hosp rate change","23","Maine","category","increase",0.184300905834661
+2022-11-28,"2 wk flu hosp rate change","24","Maryland","category","increase",0.207246735707723
+2022-11-28,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0.150181186837582
+2022-11-28,"2 wk flu hosp rate change","26","Michigan","category","increase",0.19184453183821
+2022-11-28,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.142331684245282
+2022-11-28,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.0808755823200026
+2022-11-28,"2 wk flu hosp rate change","29","Missouri","category","increase",0.190835943988578
+2022-11-28,"2 wk flu hosp rate change","30","Montana","category","increase",0.0857051404554859
+2022-11-28,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.0972712881424967
+2022-11-28,"2 wk flu hosp rate change","32","Nevada","category","increase",0.077003107446698
+2022-11-28,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0.162195624796328
+2022-11-28,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.204752685868115
+2022-11-28,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.0846044857791674
+2022-11-28,"2 wk flu hosp rate change","36","New York","category","increase",0.207029904652741
+2022-11-28,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.191780358341232
+2022-11-28,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.180883368429588
+2022-11-28,"2 wk flu hosp rate change","39","Ohio","category","increase",0.161385391891529
+2022-11-28,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.129357298115539
+2022-11-28,"2 wk flu hosp rate change","41","Oregon","category","increase",0.116626351785842
+2022-11-28,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.170773956393666
+2022-11-28,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.073354934786621
+2022-11-28,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.224125476370478
+2022-11-28,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.14217979062199
+2022-11-28,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.15805437452503
+2022-11-28,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.120735865263052
+2022-11-28,"2 wk flu hosp rate change","48","Texas","category","increase",0.121118875213228
+2022-11-28,"2 wk flu hosp rate change","US","US","category","increase",0.188813827477401
+2022-11-28,"2 wk flu hosp rate change","49","Utah","category","increase",0.215785720490046
+2022-11-28,"2 wk flu hosp rate change","50","Vermont","category","increase",0.208485323584668
+2022-11-28,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-11-28,"2 wk flu hosp rate change","51","Virginia","category","increase",0.144029770601922
+2022-11-28,"2 wk flu hosp rate change","53","Washington","category","increase",0.190295369202135
+2022-11-28,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.0425931585397005
+2022-11-28,"2 wk flu hosp rate change","55","Wisconsin","category","increase",0.166179322669412
+2022-11-28,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.14297857251295
+2022-11-28,"2 wk flu hosp rate change","01","Alabama","category","stable",0.36996258711387
+2022-11-28,"2 wk flu hosp rate change","02","Alaska","category","stable",0.304603907579078
+2022-11-28,"2 wk flu hosp rate change","04","Arizona","category","stable",0.291990796420671
+2022-11-28,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.170280606060393
+2022-11-28,"2 wk flu hosp rate change","06","California","category","stable",0.293474343350381
+2022-11-28,"2 wk flu hosp rate change","08","Colorado","category","stable",0.368686450598484
+2022-11-28,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.225464579801701
+2022-11-28,"2 wk flu hosp rate change","10","Delaware","category","stable",0.435343998935886
+2022-11-28,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.267591106754956
+2022-11-28,"2 wk flu hosp rate change","12","Florida","category","stable",0.522362694786841
+2022-11-28,"2 wk flu hosp rate change","13","Georgia","category","stable",0.665670934715161
+2022-11-28,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.738178082350985
+2022-11-28,"2 wk flu hosp rate change","16","Idaho","category","stable",0.239123940865958
+2022-11-28,"2 wk flu hosp rate change","17","Illinois","category","stable",0.3211844448663
+2022-11-28,"2 wk flu hosp rate change","18","Indiana","category","stable",0.270204883389591
+2022-11-28,"2 wk flu hosp rate change","19","Iowa","category","stable",0.426621879214722
+2022-11-28,"2 wk flu hosp rate change","20","Kansas","category","stable",0.382205663892649
+2022-11-28,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.17388512906447
+2022-11-28,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.497425763703116
+2022-11-28,"2 wk flu hosp rate change","23","Maine","category","stable",0.596120988451967
+2022-11-28,"2 wk flu hosp rate change","24","Maryland","category","stable",0.357011534340247
+2022-11-28,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.49836365345989
+2022-11-28,"2 wk flu hosp rate change","26","Michigan","category","stable",0.508506875552317
+2022-11-28,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.249176587562063
+2022-11-28,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.319248158707348
+2022-11-28,"2 wk flu hosp rate change","29","Missouri","category","stable",0.237213504523595
+2022-11-28,"2 wk flu hosp rate change","30","Montana","category","stable",0.409278150892805
+2022-11-28,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.27620576402262
+2022-11-28,"2 wk flu hosp rate change","32","Nevada","category","stable",0.204290881105906
+2022-11-28,"2 wk flu hosp rate change","33","New Hampshire","category","stable",0.825783661955213
+2022-11-28,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.374563454470719
+2022-11-28,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.128633290065861
+2022-11-28,"2 wk flu hosp rate change","36","New York","category","stable",0.466080464169787
+2022-11-28,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.316227510309634
+2022-11-28,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.764787280175132
+2022-11-28,"2 wk flu hosp rate change","39","Ohio","category","stable",0.45142176006565
+2022-11-28,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.240877443734253
+2022-11-28,"2 wk flu hosp rate change","41","Oregon","category","stable",0.276457651190663
+2022-11-28,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.41096650733626
+2022-11-28,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.653480248483651
+2022-11-28,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.750705626143139
+2022-11-28,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.427684227434715
+2022-11-28,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.35732165430722
+2022-11-28,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.232272077677814
+2022-11-28,"2 wk flu hosp rate change","48","Texas","category","stable",0.402811707507709
+2022-11-28,"2 wk flu hosp rate change","US","US","category","stable",0.561656558441028
+2022-11-28,"2 wk flu hosp rate change","49","Utah","category","stable",0.665533240099289
+2022-11-28,"2 wk flu hosp rate change","50","Vermont","category","stable",0.732976321243308
+2022-11-28,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-11-28,"2 wk flu hosp rate change","51","Virginia","category","stable",0.438794658854431
+2022-11-28,"2 wk flu hosp rate change","53","Washington","category","stable",0.233619538943582
+2022-11-28,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.18985514916336
+2022-11-28,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.384374807721641
+2022-11-28,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.477751864803184
+2022-11-28,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.164790725245042
+2022-11-28,"2 wk flu hosp rate change","02","Alaska","category","decrease",0.150843648600506
+2022-11-28,"2 wk flu hosp rate change","04","Arizona","category","decrease",0.0770879633696514
+2022-11-28,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.0391154439185058
+2022-11-28,"2 wk flu hosp rate change","06","California","category","decrease",0.0308155059979268
+2022-11-28,"2 wk flu hosp rate change","08","Colorado","category","decrease",0.203609510808883
+2022-11-28,"2 wk flu hosp rate change","09","Connecticut","category","decrease",0.0699153783584616
+2022-11-28,"2 wk flu hosp rate change","10","Delaware","category","decrease",0.0862919246370098
+2022-11-28,"2 wk flu hosp rate change","11","District of Columbia","category","decrease",0.115995498989992
+2022-11-28,"2 wk flu hosp rate change","12","Florida","category","decrease",0.0610678654965707
+2022-11-28,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.118678226592965
+2022-11-28,"2 wk flu hosp rate change","16","Idaho","category","decrease",0.0670726918066571
+2022-11-28,"2 wk flu hosp rate change","17","Illinois","category","decrease",0.0394944200515395
+2022-11-28,"2 wk flu hosp rate change","18","Indiana","category","decrease",0.065418245648807
+2022-11-28,"2 wk flu hosp rate change","19","Iowa","category","decrease",0.141198385852542
+2022-11-28,"2 wk flu hosp rate change","20","Kansas","category","decrease",0.0512313861112472
+2022-11-28,"2 wk flu hosp rate change","21","Kentucky","category","decrease",0.0465252004806463
+2022-11-28,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.070644461044717
+2022-11-28,"2 wk flu hosp rate change","23","Maine","category","decrease",0.0362294924966161
+2022-11-28,"2 wk flu hosp rate change","24","Maryland","category","decrease",0.115973712481847
+2022-11-28,"2 wk flu hosp rate change","25","Massachusetts","category","decrease",0.0707164193945591
+2022-11-28,"2 wk flu hosp rate change","26","Michigan","category","decrease",0.0776458046609064
+2022-11-28,"2 wk flu hosp rate change","27","Minnesota","category","decrease",0.0884338454652222
+2022-11-28,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.111935512404434
+2022-11-28,"2 wk flu hosp rate change","29","Missouri","category","decrease",0.0259977958936441
+2022-11-28,"2 wk flu hosp rate change","30","Montana","category","decrease",0.119291707473787
+2022-11-28,"2 wk flu hosp rate change","31","Nebraska","category","decrease",0.111943105483266
+2022-11-28,"2 wk flu hosp rate change","32","Nevada","category","decrease",0.0963374850887305
+2022-11-28,"2 wk flu hosp rate change","34","New Jersey","category","decrease",0.0673467742425838
+2022-11-28,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0778730777223142
+2022-11-28,"2 wk flu hosp rate change","36","New York","category","decrease",0.0929490992833772
+2022-11-28,"2 wk flu hosp rate change","37","North Carolina","category","decrease",0.0700167618314246
+2022-11-28,"2 wk flu hosp rate change","39","Ohio","category","decrease",0.0588729369269155
+2022-11-28,"2 wk flu hosp rate change","40","Oklahoma","category","decrease",0.0732363543772216
+2022-11-28,"2 wk flu hosp rate change","41","Oregon","category","decrease",0.0923630349817212
+2022-11-28,"2 wk flu hosp rate change","42","Pennsylvania","category","decrease",0.0594960160095293
+2022-11-28,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.259715179452106
+2022-11-28,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.133394897185406
+2022-11-28,"2 wk flu hosp rate change","46","South Dakota","category","decrease",0.149918513799642
+2022-11-28,"2 wk flu hosp rate change","47","Tennessee","category","decrease",0.0986162428500286
+2022-11-28,"2 wk flu hosp rate change","48","Texas","category","decrease",0.166990002227075
+2022-11-28,"2 wk flu hosp rate change","US","US","category","decrease",0.0210482814984484
+2022-11-28,"2 wk flu hosp rate change","49","Utah","category","decrease",0.0106628289688461
+2022-11-28,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.171315916058322
+2022-11-28,"2 wk flu hosp rate change","53","Washington","category","decrease",0.0362895692196624
+2022-11-28,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.0624846856744931
+2022-11-28,"2 wk flu hosp rate change","55","Wisconsin","category","decrease",0.070766927039372
+2022-11-28,"2 wk flu hosp rate change","56","Wyoming","category","decrease",0.264205262110003
+2022-11-28,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.19117895682283
+2022-11-28,"2 wk flu hosp rate change","02","Alaska","category","large_decrease",0.137244618833715
+2022-11-28,"2 wk flu hosp rate change","04","Arizona","category","large_decrease",0.0657737874977294
+2022-11-28,"2 wk flu hosp rate change","05","Arkansas","category","large_decrease",0.0909523230193015
+2022-11-28,"2 wk flu hosp rate change","06","California","category","large_decrease",0.00627333259547291
+2022-11-28,"2 wk flu hosp rate change","08","Colorado","category","large_decrease",0.0648039768440014
+2022-11-28,"2 wk flu hosp rate change","09","Connecticut","category","large_decrease",0.199589789223836
+2022-11-28,"2 wk flu hosp rate change","10","Delaware","category","large_decrease",0.033775872608334
+2022-11-28,"2 wk flu hosp rate change","11","District of Columbia","category","large_decrease",0.133952781209043
+2022-11-28,"2 wk flu hosp rate change","12","Florida","category","large_decrease",0.00967200063334694
+2022-11-28,"2 wk flu hosp rate change","13","Georgia","category","large_decrease",0.000141173542269981
+2022-11-28,"2 wk flu hosp rate change","16","Idaho","category","large_decrease",0.1095939522572
+2022-11-28,"2 wk flu hosp rate change","17","Illinois","category","large_decrease",0.0207024380511002
+2022-11-28,"2 wk flu hosp rate change","18","Indiana","category","large_decrease",0.11233440533225
+2022-11-28,"2 wk flu hosp rate change","19","Iowa","category","large_decrease",0.0249291029030864
+2022-11-28,"2 wk flu hosp rate change","20","Kansas","category","large_decrease",0.063250539380173
+2022-11-28,"2 wk flu hosp rate change","21","Kentucky","category","large_decrease",0.111011857614466
+2022-11-28,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.0471793720917413
+2022-11-28,"2 wk flu hosp rate change","24","Maryland","category","large_decrease",0.0607381443323267
+2022-11-28,"2 wk flu hosp rate change","25","Massachusetts","category","large_decrease",0.0200699921592188
+2022-11-28,"2 wk flu hosp rate change","26","Michigan","category","large_decrease",0.0158146926245683
+2022-11-28,"2 wk flu hosp rate change","27","Minnesota","category","large_decrease",0.108405920724896
+2022-11-28,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.196522634508663
+2022-11-28,"2 wk flu hosp rate change","29","Missouri","category","large_decrease",0.00441660349348498
+2022-11-28,"2 wk flu hosp rate change","30","Montana","category","large_decrease",0.0812369347117278
+2022-11-28,"2 wk flu hosp rate change","31","Nebraska","category","large_decrease",0.173633363406949
+2022-11-28,"2 wk flu hosp rate change","32","Nevada","category","large_decrease",0.296898031462
+2022-11-28,"2 wk flu hosp rate change","34","New Jersey","category","large_decrease",0.0368028270940007
+2022-11-28,"2 wk flu hosp rate change","35","New Mexico","category","large_decrease",0.174989946172957
+2022-11-28,"2 wk flu hosp rate change","36","New York","category","large_decrease",0.0209551038696958
+2022-11-28,"2 wk flu hosp rate change","37","North Carolina","category","large_decrease",0.0137318004974029
+2022-11-28,"2 wk flu hosp rate change","39","Ohio","category","large_decrease",0.045633073052979
+2022-11-28,"2 wk flu hosp rate change","40","Oklahoma","category","large_decrease",0.067443219757637
+2022-11-28,"2 wk flu hosp rate change","41","Oregon","category","large_decrease",0.0886488908755492
+2022-11-28,"2 wk flu hosp rate change","42","Pennsylvania","category","large_decrease",0.0489104958685515
+2022-11-28,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",0.00570302984064411
+2022-11-28,"2 wk flu hosp rate change","45","South Carolina","category","large_decrease",0.101675424349868
+2022-11-28,"2 wk flu hosp rate change","46","South Dakota","category","large_decrease",0.0927599846873119
+2022-11-28,"2 wk flu hosp rate change","47","Tennessee","category","large_decrease",0.151400060531109
+2022-11-28,"2 wk flu hosp rate change","48","Texas","category","large_decrease",0.298848364481595
+2022-11-28,"2 wk flu hosp rate change","US","US","category","large_decrease",0.000991143592345379
+2022-11-28,"2 wk flu hosp rate change","51","Virginia","category","large_decrease",0.0458390909144005
+2022-11-28,"2 wk flu hosp rate change","53","Washington","category","large_decrease",0.0120800802948738
+2022-11-28,"2 wk flu hosp rate change","54","West Virginia","category","large_decrease",0.282955664177679
+2022-11-28,"2 wk flu hosp rate change","55","Wisconsin","category","large_decrease",0.0529786234733169

--- a/data-experimental/UMass-trends_ensemble/2022-12-05-UMass-trends_ensemble.csv
+++ b/data-experimental/UMass-trends_ensemble/2022-12-05-UMass-trends_ensemble.csv
@@ -1,0 +1,263 @@
+"forecast_date","target","location","location_name","type","type_id","value"
+2022-12-05,"2 wk flu hosp rate change","01","Alabama","category","large_increase",0.29793606845252
+2022-12-05,"2 wk flu hosp rate change","02","Alaska","category","large_increase",0.412999342169084
+2022-12-05,"2 wk flu hosp rate change","04","Arizona","category","large_increase",0.60689464511006
+2022-12-05,"2 wk flu hosp rate change","05","Arkansas","category","large_increase",0.4835577367585
+2022-12-05,"2 wk flu hosp rate change","06","California","category","large_increase",0.45650097518796
+2022-12-05,"2 wk flu hosp rate change","08","Colorado","category","large_increase",0.310375031065577
+2022-12-05,"2 wk flu hosp rate change","09","Connecticut","category","large_increase",0.42221051495559
+2022-12-05,"2 wk flu hosp rate change","10","Delaware","category","large_increase",0.400284301346775
+2022-12-05,"2 wk flu hosp rate change","11","District of Columbia","category","large_increase",0.327160412687991
+2022-12-05,"2 wk flu hosp rate change","12","Florida","category","large_increase",0.16849078244323
+2022-12-05,"2 wk flu hosp rate change","13","Georgia","category","large_increase",0.101906382283216
+2022-12-05,"2 wk flu hosp rate change","15","Hawaii","category","large_increase",0.114886486050643
+2022-12-05,"2 wk flu hosp rate change","16","Idaho","category","large_increase",0.571013182611707
+2022-12-05,"2 wk flu hosp rate change","17","Illinois","category","large_increase",0.478648277251836
+2022-12-05,"2 wk flu hosp rate change","18","Indiana","category","large_increase",0.606535694665442
+2022-12-05,"2 wk flu hosp rate change","19","Iowa","category","large_increase",0.453539828735967
+2022-12-05,"2 wk flu hosp rate change","20","Kansas","category","large_increase",0.525304295415245
+2022-12-05,"2 wk flu hosp rate change","21","Kentucky","category","large_increase",0.674393277698583
+2022-12-05,"2 wk flu hosp rate change","22","Louisiana","category","large_increase",0.315057336306716
+2022-12-05,"2 wk flu hosp rate change","23","Maine","category","large_increase",0.442157357353264
+2022-12-05,"2 wk flu hosp rate change","24","Maryland","category","large_increase",0.272831298715986
+2022-12-05,"2 wk flu hosp rate change","25","Massachusetts","category","large_increase",0.405411056532529
+2022-12-05,"2 wk flu hosp rate change","26","Michigan","category","large_increase",0.414684671889072
+2022-12-05,"2 wk flu hosp rate change","27","Minnesota","category","large_increase",0.460978918050776
+2022-12-05,"2 wk flu hosp rate change","28","Mississippi","category","large_increase",0.273226651576945
+2022-12-05,"2 wk flu hosp rate change","29","Missouri","category","large_increase",0.687772314150709
+2022-12-05,"2 wk flu hosp rate change","30","Montana","category","large_increase",0.337075257659786
+2022-12-05,"2 wk flu hosp rate change","31","Nebraska","category","large_increase",0.392616662990592
+2022-12-05,"2 wk flu hosp rate change","32","Nevada","category","large_increase",0.567799267672021
+2022-12-05,"2 wk flu hosp rate change","33","New Hampshire","category","large_increase",0.137880198052062
+2022-12-05,"2 wk flu hosp rate change","34","New Jersey","category","large_increase",0.524043310296949
+2022-12-05,"2 wk flu hosp rate change","35","New Mexico","category","large_increase",0.561584277468815
+2022-12-05,"2 wk flu hosp rate change","36","New York","category","large_increase",0.380189040209031
+2022-12-05,"2 wk flu hosp rate change","37","North Carolina","category","large_increase",0.353610142186089
+2022-12-05,"2 wk flu hosp rate change","38","North Dakota","category","large_increase",0.331293500466012
+2022-12-05,"2 wk flu hosp rate change","39","Ohio","category","large_increase",0.376063459210512
+2022-12-05,"2 wk flu hosp rate change","40","Oklahoma","category","large_increase",0.683144351811981
+2022-12-05,"2 wk flu hosp rate change","41","Oregon","category","large_increase",0.587650518999179
+2022-12-05,"2 wk flu hosp rate change","42","Pennsylvania","category","large_increase",0.555037350363
+2022-12-05,"2 wk flu hosp rate change","72","Puerto Rico","category","large_increase",0.138725909070264
+2022-12-05,"2 wk flu hosp rate change","44","Rhode Island","category","large_increase",0.0949322449267945
+2022-12-05,"2 wk flu hosp rate change","45","South Carolina","category","large_increase",0.129239213688685
+2022-12-05,"2 wk flu hosp rate change","46","South Dakota","category","large_increase",0.331278792252075
+2022-12-05,"2 wk flu hosp rate change","47","Tennessee","category","large_increase",0.471715253482791
+2022-12-05,"2 wk flu hosp rate change","48","Texas","category","large_increase",0.357780692080208
+2022-12-05,"2 wk flu hosp rate change","US","US","category","large_increase",0.413282339906317
+2022-12-05,"2 wk flu hosp rate change","49","Utah","category","large_increase",0.0720798049799714
+2022-12-05,"2 wk flu hosp rate change","50","Vermont","category","large_increase",0.205785408189654
+2022-12-05,"2 wk flu hosp rate change","78","Virgin Islands","category","large_increase",0
+2022-12-05,"2 wk flu hosp rate change","51","Virginia","category","large_increase",0.241043136806535
+2022-12-05,"2 wk flu hosp rate change","53","Washington","category","large_increase",0.572767404889224
+2022-12-05,"2 wk flu hosp rate change","54","West Virginia","category","large_increase",0.489741936503888
+2022-12-05,"2 wk flu hosp rate change","55","Wisconsin","category","large_increase",0.506706691968281
+2022-12-05,"2 wk flu hosp rate change","56","Wyoming","category","large_increase",0.372279453928341
+2022-12-05,"2 wk flu hosp rate change","01","Alabama","category","increase",0.102268560590727
+2022-12-05,"2 wk flu hosp rate change","02","Alaska","category","increase",0.0975227618534198
+2022-12-05,"2 wk flu hosp rate change","04","Arizona","category","increase",0.0912065293821523
+2022-12-05,"2 wk flu hosp rate change","05","Arkansas","category","increase",0.0693374598041319
+2022-12-05,"2 wk flu hosp rate change","06","California","category","increase",0.125617013195349
+2022-12-05,"2 wk flu hosp rate change","08","Colorado","category","increase",0.131424188991454
+2022-12-05,"2 wk flu hosp rate change","09","Connecticut","category","increase",0.0472758461106878
+2022-12-05,"2 wk flu hosp rate change","10","Delaware","category","increase",0.140793306146111
+2022-12-05,"2 wk flu hosp rate change","11","District of Columbia","category","increase",0.123688204468833
+2022-12-05,"2 wk flu hosp rate change","12","Florida","category","increase",0.255754439725991
+2022-12-05,"2 wk flu hosp rate change","13","Georgia","category","increase",0.165090706263343
+2022-12-05,"2 wk flu hosp rate change","15","Hawaii","category","increase",0.136272887474977
+2022-12-05,"2 wk flu hosp rate change","16","Idaho","category","increase",0.0822352611394882
+2022-12-05,"2 wk flu hosp rate change","17","Illinois","category","increase",0.197727410093695
+2022-12-05,"2 wk flu hosp rate change","18","Indiana","category","increase",0.0946850842504385
+2022-12-05,"2 wk flu hosp rate change","19","Iowa","category","increase",0.0544126875595654
+2022-12-05,"2 wk flu hosp rate change","20","Kansas","category","increase",0.108542027450155
+2022-12-05,"2 wk flu hosp rate change","21","Kentucky","category","increase",0.0688085210202344
+2022-12-05,"2 wk flu hosp rate change","22","Louisiana","category","increase",0.134464967271001
+2022-12-05,"2 wk flu hosp rate change","23","Maine","category","increase",0.084352210878649
+2022-12-05,"2 wk flu hosp rate change","24","Maryland","category","increase",0.213853601238246
+2022-12-05,"2 wk flu hosp rate change","25","Massachusetts","category","increase",0.194886626263481
+2022-12-05,"2 wk flu hosp rate change","26","Michigan","category","increase",0.227738729420813
+2022-12-05,"2 wk flu hosp rate change","27","Minnesota","category","increase",0.108663471053697
+2022-12-05,"2 wk flu hosp rate change","28","Mississippi","category","increase",0.0690718336316093
+2022-12-05,"2 wk flu hosp rate change","29","Missouri","category","increase",0.0654440962449049
+2022-12-05,"2 wk flu hosp rate change","30","Montana","category","increase",0.133806265441461
+2022-12-05,"2 wk flu hosp rate change","31","Nebraska","category","increase",0.0757298644808027
+2022-12-05,"2 wk flu hosp rate change","32","Nevada","category","increase",0.0741362523304746
+2022-12-05,"2 wk flu hosp rate change","33","New Hampshire","category","increase",0.137235375454779
+2022-12-05,"2 wk flu hosp rate change","34","New Jersey","category","increase",0.132090487256477
+2022-12-05,"2 wk flu hosp rate change","35","New Mexico","category","increase",0.0611979618283409
+2022-12-05,"2 wk flu hosp rate change","36","New York","category","increase",0.256579474052091
+2022-12-05,"2 wk flu hosp rate change","37","North Carolina","category","increase",0.122581704265395
+2022-12-05,"2 wk flu hosp rate change","38","North Dakota","category","increase",0.110060916609817
+2022-12-05,"2 wk flu hosp rate change","39","Ohio","category","increase",0.145260455016862
+2022-12-05,"2 wk flu hosp rate change","40","Oklahoma","category","increase",0.0540434263187305
+2022-12-05,"2 wk flu hosp rate change","41","Oregon","category","increase",0.105134146263873
+2022-12-05,"2 wk flu hosp rate change","42","Pennsylvania","category","increase",0.134526006638985
+2022-12-05,"2 wk flu hosp rate change","72","Puerto Rico","category","increase",0.140961192886068
+2022-12-05,"2 wk flu hosp rate change","44","Rhode Island","category","increase",0.205560553171317
+2022-12-05,"2 wk flu hosp rate change","45","South Carolina","category","increase",0.183136668203494
+2022-12-05,"2 wk flu hosp rate change","46","South Dakota","category","increase",0.126190285245607
+2022-12-05,"2 wk flu hosp rate change","47","Tennessee","category","increase",0.157456197402734
+2022-12-05,"2 wk flu hosp rate change","48","Texas","category","increase",0.256988804778096
+2022-12-05,"2 wk flu hosp rate change","US","US","category","increase",0.269951673269952
+2022-12-05,"2 wk flu hosp rate change","49","Utah","category","increase",0.195917059245492
+2022-12-05,"2 wk flu hosp rate change","50","Vermont","category","increase",0.145040196839806
+2022-12-05,"2 wk flu hosp rate change","78","Virgin Islands","category","increase",0
+2022-12-05,"2 wk flu hosp rate change","51","Virginia","category","increase",0.13928346584299
+2022-12-05,"2 wk flu hosp rate change","53","Washington","category","increase",0.113211192439107
+2022-12-05,"2 wk flu hosp rate change","54","West Virginia","category","increase",0.0603579307202907
+2022-12-05,"2 wk flu hosp rate change","55","Wisconsin","category","increase",0.16078074299118
+2022-12-05,"2 wk flu hosp rate change","56","Wyoming","category","increase",0.100300757057271
+2022-12-05,"2 wk flu hosp rate change","01","Alabama","category","stable",0.310519138780867
+2022-12-05,"2 wk flu hosp rate change","02","Alaska","category","stable",0.310021587037228
+2022-12-05,"2 wk flu hosp rate change","04","Arizona","category","stable",0.117568357970862
+2022-12-05,"2 wk flu hosp rate change","05","Arkansas","category","stable",0.130706369726028
+2022-12-05,"2 wk flu hosp rate change","06","California","category","stable",0.220072119487134
+2022-12-05,"2 wk flu hosp rate change","08","Colorado","category","stable",0.401089538958058
+2022-12-05,"2 wk flu hosp rate change","09","Connecticut","category","stable",0.124574172883696
+2022-12-05,"2 wk flu hosp rate change","10","Delaware","category","stable",0.246099981206902
+2022-12-05,"2 wk flu hosp rate change","11","District of Columbia","category","stable",0.38040008894038
+2022-12-05,"2 wk flu hosp rate change","12","Florida","category","stable",0.496297823846973
+2022-12-05,"2 wk flu hosp rate change","13","Georgia","category","stable",0.5812816491192
+2022-12-05,"2 wk flu hosp rate change","15","Hawaii","category","stable",0.74884062647438
+2022-12-05,"2 wk flu hosp rate change","16","Idaho","category","stable",0.109784071650556
+2022-12-05,"2 wk flu hosp rate change","17","Illinois","category","stable",0.176605909140096
+2022-12-05,"2 wk flu hosp rate change","18","Indiana","category","stable",0.145369804929867
+2022-12-05,"2 wk flu hosp rate change","19","Iowa","category","stable",0.173120926411467
+2022-12-05,"2 wk flu hosp rate change","20","Kansas","category","stable",0.159157143391084
+2022-12-05,"2 wk flu hosp rate change","21","Kentucky","category","stable",0.113633758187421
+2022-12-05,"2 wk flu hosp rate change","22","Louisiana","category","stable",0.329554370862954
+2022-12-05,"2 wk flu hosp rate change","23","Maine","category","stable",0.269591191164854
+2022-12-05,"2 wk flu hosp rate change","24","Maryland","category","stable",0.367582197468642
+2022-12-05,"2 wk flu hosp rate change","25","Massachusetts","category","stable",0.250944026053911
+2022-12-05,"2 wk flu hosp rate change","26","Michigan","category","stable",0.224388946588377
+2022-12-05,"2 wk flu hosp rate change","27","Minnesota","category","stable",0.197185957450454
+2022-12-05,"2 wk flu hosp rate change","28","Mississippi","category","stable",0.246515188392229
+2022-12-05,"2 wk flu hosp rate change","29","Missouri","category","stable",0.108521260716197
+2022-12-05,"2 wk flu hosp rate change","30","Montana","category","stable",0.277786447159553
+2022-12-05,"2 wk flu hosp rate change","31","Nebraska","category","stable",0.262745078751335
+2022-12-05,"2 wk flu hosp rate change","32","Nevada","category","stable",0.0935741440211749
+2022-12-05,"2 wk flu hosp rate change","33","New Hampshire","category","stable",0.526040048163008
+2022-12-05,"2 wk flu hosp rate change","34","New Jersey","category","stable",0.138739699824561
+2022-12-05,"2 wk flu hosp rate change","35","New Mexico","category","stable",0.102923620816251
+2022-12-05,"2 wk flu hosp rate change","36","New York","category","stable",0.274307471016572
+2022-12-05,"2 wk flu hosp rate change","37","North Carolina","category","stable",0.314031886813692
+2022-12-05,"2 wk flu hosp rate change","38","North Dakota","category","stable",0.385734485747394
+2022-12-05,"2 wk flu hosp rate change","39","Ohio","category","stable",0.283032681826102
+2022-12-05,"2 wk flu hosp rate change","40","Oklahoma","category","stable",0.0966704580728546
+2022-12-05,"2 wk flu hosp rate change","41","Oregon","category","stable",0.136454229643497
+2022-12-05,"2 wk flu hosp rate change","42","Pennsylvania","category","stable",0.180211515893612
+2022-12-05,"2 wk flu hosp rate change","72","Puerto Rico","category","stable",0.527506128199667
+2022-12-05,"2 wk flu hosp rate change","44","Rhode Island","category","stable",0.648825198197651
+2022-12-05,"2 wk flu hosp rate change","45","South Carolina","category","stable",0.592457729658901
+2022-12-05,"2 wk flu hosp rate change","46","South Dakota","category","stable",0.341722039462422
+2022-12-05,"2 wk flu hosp rate change","47","Tennessee","category","stable",0.185226655641412
+2022-12-05,"2 wk flu hosp rate change","48","Texas","category","stable",0.351453693454054
+2022-12-05,"2 wk flu hosp rate change","US","US","category","stable",0.275173159728712
+2022-12-05,"2 wk flu hosp rate change","49","Utah","category","stable",0.681300021353936
+2022-12-05,"2 wk flu hosp rate change","50","Vermont","category","stable",0.471118314935223
+2022-12-05,"2 wk flu hosp rate change","78","Virgin Islands","category","stable",1
+2022-12-05,"2 wk flu hosp rate change","51","Virginia","category","stable",0.344615770345007
+2022-12-05,"2 wk flu hosp rate change","53","Washington","category","stable",0.177237156105629
+2022-12-05,"2 wk flu hosp rate change","54","West Virginia","category","stable",0.0953948493671855
+2022-12-05,"2 wk flu hosp rate change","55","Wisconsin","category","stable",0.174210344586756
+2022-12-05,"2 wk flu hosp rate change","56","Wyoming","category","stable",0.244334467310825
+2022-12-05,"2 wk flu hosp rate change","01","Alabama","category","decrease",0.109937697517087
+2022-12-05,"2 wk flu hosp rate change","02","Alaska","category","decrease",0.0934942384260181
+2022-12-05,"2 wk flu hosp rate change","04","Arizona","category","decrease",0.0532467803233685
+2022-12-05,"2 wk flu hosp rate change","05","Arkansas","category","decrease",0.0497822252813278
+2022-12-05,"2 wk flu hosp rate change","06","California","category","decrease",0.0852125496073701
+2022-12-05,"2 wk flu hosp rate change","08","Colorado","category","decrease",0.118825154102084
+2022-12-05,"2 wk flu hosp rate change","09","Connecticut","category","decrease",0.0636039570657456
+2022-12-05,"2 wk flu hosp rate change","10","Delaware","category","decrease",0.0969715403287055
+2022-12-05,"2 wk flu hosp rate change","11","District of Columbia","category","decrease",0.0955310200492896
+2022-12-05,"2 wk flu hosp rate change","12","Florida","category","decrease",0.0705113685478625
+2022-12-05,"2 wk flu hosp rate change","13","Georgia","category","decrease",0.151721262254146
+2022-12-05,"2 wk flu hosp rate change","16","Idaho","category","decrease",0.0439091047774888
+2022-12-05,"2 wk flu hosp rate change","17","Illinois","category","decrease",0.0585213870274173
+2022-12-05,"2 wk flu hosp rate change","18","Indiana","category","decrease",0.0509509165305355
+2022-12-05,"2 wk flu hosp rate change","19","Iowa","category","decrease",0.0781566040171127
+2022-12-05,"2 wk flu hosp rate change","20","Kansas","category","decrease",0.0678967639195631
+2022-12-05,"2 wk flu hosp rate change","21","Kentucky","category","decrease",0.0343834536256801
+2022-12-05,"2 wk flu hosp rate change","22","Louisiana","category","decrease",0.11209008975461
+2022-12-05,"2 wk flu hosp rate change","23","Maine","category","decrease",0.0629873515250809
+2022-12-05,"2 wk flu hosp rate change","24","Maryland","category","decrease",0.0957106271493245
+2022-12-05,"2 wk flu hosp rate change","25","Massachusetts","category","decrease",0.0760382070727632
+2022-12-05,"2 wk flu hosp rate change","26","Michigan","category","decrease",0.0614858446293684
+2022-12-05,"2 wk flu hosp rate change","27","Minnesota","category","decrease",0.0663648156076338
+2022-12-05,"2 wk flu hosp rate change","28","Mississippi","category","decrease",0.0870501528464729
+2022-12-05,"2 wk flu hosp rate change","29","Missouri","category","decrease",0.0393427811221386
+2022-12-05,"2 wk flu hosp rate change","30","Montana","category","decrease",0.140105045450919
+2022-12-05,"2 wk flu hosp rate change","31","Nebraska","category","decrease",0.118858058258061
+2022-12-05,"2 wk flu hosp rate change","32","Nevada","category","decrease",0.0374411061105075
+2022-12-05,"2 wk flu hosp rate change","33","New Hampshire","category","decrease",0.198844378330151
+2022-12-05,"2 wk flu hosp rate change","34","New Jersey","category","decrease",0.0540655903079684
+2022-12-05,"2 wk flu hosp rate change","35","New Mexico","category","decrease",0.0361982737549713
+2022-12-05,"2 wk flu hosp rate change","36","New York","category","decrease",0.0623908206887934
+2022-12-05,"2 wk flu hosp rate change","37","North Carolina","category","decrease",0.11618003140393
+2022-12-05,"2 wk flu hosp rate change","38","North Dakota","category","decrease",0.114118259412604
+2022-12-05,"2 wk flu hosp rate change","39","Ohio","category","decrease",0.0870110466968614
+2022-12-05,"2 wk flu hosp rate change","40","Oklahoma","category","decrease",0.0411877333263045
+2022-12-05,"2 wk flu hosp rate change","41","Oregon","category","decrease",0.0442806822326105
+2022-12-05,"2 wk flu hosp rate change","42","Pennsylvania","category","decrease",0.0564800030297569
+2022-12-05,"2 wk flu hosp rate change","72","Puerto Rico","category","decrease",0.192806769844001
+2022-12-05,"2 wk flu hosp rate change","44","Rhode Island","category","decrease",0.0506820037042372
+2022-12-05,"2 wk flu hosp rate change","45","South Carolina","category","decrease",0.0815161925515105
+2022-12-05,"2 wk flu hosp rate change","46","South Dakota","category","decrease",0.100740487695101
+2022-12-05,"2 wk flu hosp rate change","47","Tennessee","category","decrease",0.0651151782080381
+2022-12-05,"2 wk flu hosp rate change","48","Texas","category","decrease",0.0261636117253624
+2022-12-05,"2 wk flu hosp rate change","US","US","category","decrease",0.0311348574843357
+2022-12-05,"2 wk flu hosp rate change","49","Utah","category","decrease",0.0507031144206008
+2022-12-05,"2 wk flu hosp rate change","50","Vermont","category","decrease",0.178056080035317
+2022-12-05,"2 wk flu hosp rate change","51","Virginia","category","decrease",0.132133725590007
+2022-12-05,"2 wk flu hosp rate change","53","Washington","category","decrease",0.0555684501096327
+2022-12-05,"2 wk flu hosp rate change","54","West Virginia","category","decrease",0.0456346782762465
+2022-12-05,"2 wk flu hosp rate change","55","Wisconsin","category","decrease",0.0617900795274536
+2022-12-05,"2 wk flu hosp rate change","56","Wyoming","category","decrease",0.13169370607858
+2022-12-05,"2 wk flu hosp rate change","01","Alabama","category","large_decrease",0.179338534658799
+2022-12-05,"2 wk flu hosp rate change","02","Alaska","category","large_decrease",0.0859620705142504
+2022-12-05,"2 wk flu hosp rate change","04","Arizona","category","large_decrease",0.131083687213557
+2022-12-05,"2 wk flu hosp rate change","05","Arkansas","category","large_decrease",0.266616208430013
+2022-12-05,"2 wk flu hosp rate change","06","California","category","large_decrease",0.112597342522186
+2022-12-05,"2 wk flu hosp rate change","08","Colorado","category","large_decrease",0.0382860868828272
+2022-12-05,"2 wk flu hosp rate change","09","Connecticut","category","large_decrease",0.342335508984281
+2022-12-05,"2 wk flu hosp rate change","10","Delaware","category","large_decrease",0.115850870971507
+2022-12-05,"2 wk flu hosp rate change","11","District of Columbia","category","large_decrease",0.073220273853507
+2022-12-05,"2 wk flu hosp rate change","12","Florida","category","large_decrease",0.00894558543594302
+2022-12-05,"2 wk flu hosp rate change","13","Georgia","category","large_decrease",8.00955581905441e-11
+2022-12-05,"2 wk flu hosp rate change","16","Idaho","category","large_decrease",0.19305837982076
+2022-12-05,"2 wk flu hosp rate change","17","Illinois","category","large_decrease",0.0884970164869563
+2022-12-05,"2 wk flu hosp rate change","18","Indiana","category","large_decrease",0.102458499623716
+2022-12-05,"2 wk flu hosp rate change","19","Iowa","category","large_decrease",0.240769953275888
+2022-12-05,"2 wk flu hosp rate change","20","Kansas","category","large_decrease",0.139099769823953
+2022-12-05,"2 wk flu hosp rate change","21","Kentucky","category","large_decrease",0.108780989468082
+2022-12-05,"2 wk flu hosp rate change","22","Louisiana","category","large_decrease",0.10883323580472
+2022-12-05,"2 wk flu hosp rate change","23","Maine","category","large_decrease",0.140911889078153
+2022-12-05,"2 wk flu hosp rate change","24","Maryland","category","large_decrease",0.0500222754278009
+2022-12-05,"2 wk flu hosp rate change","25","Massachusetts","category","large_decrease",0.072720084077316
+2022-12-05,"2 wk flu hosp rate change","26","Michigan","category","large_decrease",0.0717018074723699
+2022-12-05,"2 wk flu hosp rate change","27","Minnesota","category","large_decrease",0.166806837837439
+2022-12-05,"2 wk flu hosp rate change","28","Mississippi","category","large_decrease",0.324136173552743
+2022-12-05,"2 wk flu hosp rate change","29","Missouri","category","large_decrease",0.0989195477660509
+2022-12-05,"2 wk flu hosp rate change","30","Montana","category","large_decrease",0.11122698428828
+2022-12-05,"2 wk flu hosp rate change","31","Nebraska","category","large_decrease",0.15005033551921
+2022-12-05,"2 wk flu hosp rate change","32","Nevada","category","large_decrease",0.227049229865822
+2022-12-05,"2 wk flu hosp rate change","34","New Jersey","category","large_decrease",0.151060912314044
+2022-12-05,"2 wk flu hosp rate change","35","New Mexico","category","large_decrease",0.238095866131622
+2022-12-05,"2 wk flu hosp rate change","36","New York","category","large_decrease",0.0265331940335125
+2022-12-05,"2 wk flu hosp rate change","37","North Carolina","category","large_decrease",0.0935962353308945
+2022-12-05,"2 wk flu hosp rate change","38","North Dakota","category","large_decrease",0.0587928377641741
+2022-12-05,"2 wk flu hosp rate change","39","Ohio","category","large_decrease",0.108632357249664
+2022-12-05,"2 wk flu hosp rate change","40","Oklahoma","category","large_decrease",0.124954030470129
+2022-12-05,"2 wk flu hosp rate change","41","Oregon","category","large_decrease",0.12648042286084
+2022-12-05,"2 wk flu hosp rate change","42","Pennsylvania","category","large_decrease",0.0737451240746456
+2022-12-05,"2 wk flu hosp rate change","72","Puerto Rico","category","large_decrease",5.40417582375162e-279
+2022-12-05,"2 wk flu hosp rate change","45","South Carolina","category","large_decrease",0.01365019589741
+2022-12-05,"2 wk flu hosp rate change","46","South Dakota","category","large_decrease",0.100068395344794
+2022-12-05,"2 wk flu hosp rate change","47","Tennessee","category","large_decrease",0.120486715265025
+2022-12-05,"2 wk flu hosp rate change","48","Texas","category","large_decrease",0.00761319796227912
+2022-12-05,"2 wk flu hosp rate change","US","US","category","large_decrease",0.0104579696106836
+2022-12-05,"2 wk flu hosp rate change","51","Virginia","category","large_decrease",0.14292390141546
+2022-12-05,"2 wk flu hosp rate change","53","Washington","category","large_decrease",0.0812157964564079
+2022-12-05,"2 wk flu hosp rate change","54","West Virginia","category","large_decrease",0.308870605132389
+2022-12-05,"2 wk flu hosp rate change","55","Wisconsin","category","large_decrease",0.0965121409263297
+2022-12-05,"2 wk flu hosp rate change","56","Wyoming","category","large_decrease",0.151391615624983


### PR DESCRIPTION
forecasts use UMass-trends_ensemble  forecasts submitted in real time to FluSight. only truth data that was available at the time of the corresponding initial forecast dates were used in the generation of retrospective forecasts